### PR TITLE
Fix create screen navigation path

### DIFF
--- a/app/(tabs)/index.tsx
+++ b/app/(tabs)/index.tsx
@@ -13,7 +13,7 @@ const quickActions = [
     description: 'Créer un courrier personnalisé',
     icon: Plus,
     color: '#22c55e',
-    action: () => router.push('/create'),
+    action: () => router.push('/(tabs)/create'),
   },
   {
     id: 'recent',
@@ -109,7 +109,7 @@ export default function HomeScreen() {
           </Text>
           <Button
             title="Créer un courrier"
-            onPress={() => router.push('/create')}
+            onPress={() => router.push('/(tabs)/create')}
             size="large"
           />
         </Card>


### PR DESCRIPTION
## Summary
- fix router paths for create screen so navigation stays within tab stack

## Testing
- `npm run lint` *(fails: expo not found)*

------
https://chatgpt.com/codex/tasks/task_e_684abde1f8d48320824c27a734ec92a6