### PR TITLE
Improve documentation for running project

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,24 @@
-# assistant-courrier
+# Assistant Courrier
+
+A React Native application built with [Expo](https://expo.dev/).
+
+## Requirements
+
+- [Node.js](https://nodejs.org/) (version 18 or newer)
+- Expo CLI (install via `npm install --global expo-cli` or use `npx expo`)
+
+## Setup
+
+Install dependencies and start the development server:
+
+```bash
+npm install
+npm run dev
+```
+
+The `dev` script launches the Expo development server. Follow the instructions in the terminal to open the app in a simulator, the Expo Go app, or a web browser.
+
+### Additional npm scripts
+
+- `npm run build:web` – export the application as static web files.
+- `npm run lint` – run Expo's linter.


### PR DESCRIPTION
## Summary
- document Node.js and Expo requirements
- explain how to install deps and start the dev server
- list available npm scripts

## Testing
- `npm run lint` *(fails: expo not found)*

------
https://chatgpt.com/codex/tasks/task_e_684abdf7acc48320997434ebf54feebe