### PR TITLE
Add ChatGPT letter generation with profile context

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,16 @@ npm run dev
 
 The `dev` script launches the Expo development server. Follow the instructions in the terminal to open the app in a simulator, the Expo Go app, or a web browser.
 
+## OpenAI configuration
+
+The preview screen uses the OpenAI ChatGPT API to generate letters. Provide your API key with the environment variable `EXPO_PUBLIC_OPENAI_API_KEY` when running the app:
+
+```bash
+EXPO_PUBLIC_OPENAI_API_KEY=sk-your-key npm run dev
+```
+
+Without this variable the letter generation will fail.
+
 ### Additional npm scripts
 
 - `npm run build:web` – export the application as static web files.

--- a/app/(tabs)/create/preview.tsx
+++ b/app/(tabs)/create/preview.tsx
@@ -5,6 +5,7 @@ import { Header } from '@/components/ui/Header';
 import { Card } from '@/components/ui/Card';
 import { Button } from '@/components/ui/Button';
 import { ArrowLeft, Download, Share2, Copy, Mail, Sparkles } from 'lucide-react-native';
+import { useProfile } from '@/contexts/ProfileContext';
 
 interface RecipientData {
   service: string;
@@ -35,6 +36,7 @@ export default function PreviewScreen() {
   const [details, setDetails] = useState<DetailsData | null>(null);
   const [generatedLetter, setGeneratedLetter] = useState<string>('');
   const [isGenerating, setIsGenerating] = useState(false);
+  const { profile } = useProfile();
 
   useEffect(() => {
     if (recipientData) {
@@ -62,40 +64,35 @@ export default function PreviewScreen() {
 
   const generateLetter = async () => {
     setIsGenerating(true);
-    
-    // Simulation de génération de lettre (remplacer par appel API ChatGPT)
-    setTimeout(() => {
-      const mockLetter = generateMockLetter();
-      setGeneratedLetter(mockLetter);
+    try {
+      const response = await fetch('https://api.openai.com/v1/chat/completions', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          Authorization: `Bearer ${process.env.EXPO_PUBLIC_OPENAI_API_KEY}`,
+        },
+        body: JSON.stringify({
+          model: 'gpt-3.5-turbo',
+          messages: [
+            { role: 'system', content: 'Vous rédigez des courriers formels en français.' },
+            { role: 'user', content: generatePrompt() },
+          ],
+          max_tokens: 500,
+        }),
+      });
+
+      if (!response.ok) {
+        throw new Error('Failed to fetch');
+      }
+
+      const data = await response.json();
+      setGeneratedLetter(data.choices[0].message.content.trim());
+    } catch (error) {
+      console.error('Error generating letter:', error);
+      Alert.alert('Erreur', "La génération du courrier a échoué.");
+    } finally {
       setIsGenerating(false);
-    }, 2000);
-  };
-
-  const generateMockLetter = (): string => {
-    const today = new Date().toLocaleDateString('fr-FR');
-    
-    return `Jean Dupont
-123 rue de la République
-75001 Paris
-
-${recipient?.service}
-À l'attention de ${recipient?.firstName} ${recipient?.lastName}
-${recipient?.address}
-${recipient?.postalCode} ${recipient?.city}
-
-Paris, le ${today}
-
-Objet : ${getLetterSubject()}
-
-${getLetterSalutation()},
-
-${getLetterBody()}
-
-${getLetterClosing()}
-
-Cordialement,
-
-Jean Dupont`;
+    }
   };
 
   const getLetterSubject = (): string => {
@@ -164,6 +161,10 @@ ${details?.additionalInfo || ''}`;
       default:
         return 'Je vous prie d\'agréer mes salutations distinguées.';
     }
+  };
+
+  const generatePrompt = (): string => {
+    return `Expéditeur :\n${profile.firstName} ${profile.lastName}\n${profile.address}\n${profile.postalCode} ${profile.city}\n\nDestinataire :\n${recipient?.service}\n${recipient?.firstName} ${recipient?.lastName}\n${recipient?.address}\n${recipient?.postalCode} ${recipient?.city}\n\nObjet : ${getLetterSubject()}\n\nDétails : ${details?.reason ?? ''}\n${details?.additionalInfo ?? ''}\nNuméro : ${details?.contractNumber ?? ''}\nDate : ${details?.subscriptionDate ?? ''}\nMontant : ${details?.amount ?? ''}\n\nRédige ce courrier de manière formelle en français avec la salutation "${getLetterSalutation()}" et une conclusion appropriée.`;
   };
 
   const handleBack = () => {

--- a/app/(tabs)/profile.tsx
+++ b/app/(tabs)/profile.tsx
@@ -1,41 +1,26 @@
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 import { View, Text, StyleSheet, ScrollView, Alert } from 'react-native';
 import { Header } from '@/components/ui/Header';
 import { Card } from '@/components/ui/Card';
 import { Button } from '@/components/ui/Button';
 import { Input } from '@/components/ui/Input';
 import { User, Mail, MapPin, Phone, Building } from 'lucide-react-native';
-
-interface ProfileData {
-  firstName: string;
-  lastName: string;
-  email: string;
-  phone: string;
-  address: string;
-  postalCode: string;
-  city: string;
-  company?: string;
-  position?: string;
-}
+import { useProfile, ProfileData } from '@/contexts/ProfileContext';
 
 export default function ProfileScreen() {
   const [isEditing, setIsEditing] = useState(false);
-  const [profileData, setProfileData] = useState<ProfileData>({
-    firstName: 'Jean',
-    lastName: 'Dupont',
-    email: 'jean.dupont@email.com',
-    phone: '06 12 34 56 78',
-    address: '123 rue de la République',
-    postalCode: '75001',
-    city: 'Paris',
-    company: 'Entreprise SARL',
-    position: 'Développeur',
-  });
+  const { profile: profileData, setProfile } = useProfile();
 
   const [editData, setEditData] = useState<ProfileData>(profileData);
 
+  useEffect(() => {
+    if (isEditing) {
+      setEditData(profileData);
+    }
+  }, [isEditing, profileData]);
+
   const handleSave = () => {
-    setProfileData(editData);
+    setProfile(editData);
     setIsEditing(false);
     Alert.alert('Succès', 'Votre profil a été mis à jour avec succès.');
   };

--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -4,6 +4,7 @@ import { StatusBar } from 'expo-status-bar';
 import { useFrameworkReady } from '@/hooks/useFrameworkReady';
 import { useFonts, Inter_400Regular, Inter_500Medium, Inter_600SemiBold, Inter_700Bold } from '@expo-google-fonts/inter';
 import * as SplashScreen from 'expo-splash-screen';
+import { ProfileProvider } from '@/contexts/ProfileContext';
 
 SplashScreen.preventAutoHideAsync();
 
@@ -28,12 +29,14 @@ export default function RootLayout() {
   }
 
   return (
-    <>
-      <Stack screenOptions={{ headerShown: false }}>
-        <Stack.Screen name="(tabs)" options={{ headerShown: false }} />
-        <Stack.Screen name="+not-found" />
-      </Stack>
-      <StatusBar style="auto" />
-    </>
+    <ProfileProvider>
+      <>
+        <Stack screenOptions={{ headerShown: false }}>
+          <Stack.Screen name="(tabs)" options={{ headerShown: false }} />
+          <Stack.Screen name="+not-found" />
+        </Stack>
+        <StatusBar style="auto" />
+      </>
+    </ProfileProvider>
   );
 }

--- a/contexts/ProfileContext.tsx
+++ b/contexts/ProfileContext.tsx
@@ -1,0 +1,47 @@
+import React, { createContext, useContext, useState } from 'react';
+
+export interface ProfileData {
+  firstName: string;
+  lastName: string;
+  email: string;
+  phone: string;
+  address: string;
+  postalCode: string;
+  city: string;
+  company?: string;
+  position?: string;
+}
+
+const defaultProfile: ProfileData = {
+  firstName: 'Jean',
+  lastName: 'Dupont',
+  email: 'jean.dupont@email.com',
+  phone: '06 12 34 56 78',
+  address: '123 rue de la République',
+  postalCode: '75001',
+  city: 'Paris',
+  company: 'Entreprise SARL',
+  position: 'Développeur',
+};
+
+interface ProfileContextProps {
+  profile: ProfileData;
+  setProfile: (data: ProfileData) => void;
+}
+
+const ProfileContext = createContext<ProfileContextProps>({
+  profile: defaultProfile,
+  setProfile: () => {},
+});
+
+export const useProfile = () => useContext(ProfileContext);
+
+export const ProfileProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
+  const [profile, setProfile] = useState<ProfileData>(defaultProfile);
+
+  return (
+    <ProfileContext.Provider value={{ profile, setProfile }}>
+      {children}
+    </ProfileContext.Provider>
+  );
+};

--- a/contexts/index.ts
+++ b/contexts/index.ts
@@ -1,0 +1,1 @@
+export * from './ProfileContext';


### PR DESCRIPTION
## Summary
- provide ProfileContext and use it across the app
- wrap application with the ProfileProvider
- use profile data in the preview screen and call OpenAI API to generate letters
- update profile screen to edit global profile data
- document OpenAI API key usage

## Testing
- `npm run lint` *(fails: "lint" is not an expo command)*
- `npx tsc --noEmit` *(fails: missing type declarations)*

------
https://chatgpt.com/codex/tasks/task_e_684abfa5a8b083208b0c6dc8ca4ea9d9