### PR TITLE
Add serverless letter generator

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,2 +1,2 @@
-EXPO_PUBLIC_OPENAI_API_KEY=sk-your-key
-
+OPENAI_API_KEY=sk-your-key
+EXPO_PUBLIC_API_URL=https://your-app.vercel.app

--- a/README.md
+++ b/README.md
@@ -18,15 +18,18 @@ npm run dev
 
 The `dev` script launches the Expo development server. Follow the instructions in the terminal to open the app in a simulator, the Expo Go app, or a web browser.
 
-## OpenAI configuration
+## Serverless API configuration
 
-The preview screen uses the OpenAI ChatGPT API to generate letters. Provide your API key with the environment variable `EXPO_PUBLIC_OPENAI_API_KEY` when running the app:
+The preview screen now calls a serverless function (`api/generate-letter.ts`) which hides the OpenAI API key on the server. Configure the following environment variables:
+
+- `OPENAI_API_KEY` – used by the serverless function. **Do not commit this key.**
+- `EXPO_PUBLIC_API_URL` – base URL of your deployment (e.g. `https://your-app.vercel.app`).
+
+Run the app with:
 
 ```bash
-EXPO_PUBLIC_OPENAI_API_KEY=sk-your-key npm run dev
+OPENAI_API_KEY=sk-your-key EXPO_PUBLIC_API_URL=https://your-app.vercel.app npm run dev
 ```
-
-Without this variable the letter generation will fail.
 
 ### Additional npm scripts
 

--- a/api/generate-letter.ts
+++ b/api/generate-letter.ts
@@ -1,0 +1,36 @@
+import type { VercelRequest, VercelResponse } from '@vercel/node';
+import { Configuration, OpenAIApi } from 'openai';
+
+const openai = new OpenAIApi(
+  new Configuration({
+    apiKey: process.env.OPENAI_API_KEY,
+  })
+);
+
+export default async function handler(req: VercelRequest, res: VercelResponse) {
+  if (req.method !== 'POST') {
+    return res.status(405).json({ error: 'Method not allowed' });
+  }
+
+  const { prompt } = req.body as { prompt?: string };
+  if (!prompt) {
+    return res.status(400).json({ error: 'Prompt missing' });
+  }
+
+  try {
+    const response = await openai.createChatCompletion({
+      model: 'gpt-3.5-turbo',
+      messages: [
+        { role: 'system', content: 'Vous rédigez des courriers formels en français.' },
+        { role: 'user', content: prompt },
+      ],
+      max_tokens: 500,
+    });
+
+    const content = response.data.choices[0].message?.content ?? '';
+    return res.status(200).json({ content });
+  } catch (err) {
+    console.error(err);
+    return res.status(500).json({ error: 'Letter generation failed' });
+  }
+}

--- a/app/(tabs)/create/preview.tsx
+++ b/app/(tabs)/create/preview.tsx
@@ -74,19 +74,13 @@ export default function PreviewScreen() {
   const generateLetter = async () => {
     setIsGenerating(true);
     try {
-      const response = await fetch('https://api.openai.com/v1/chat/completions', {
+      const response = await fetch(`${process.env.EXPO_PUBLIC_API_URL}/api/generate-letter`, {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',
-          Authorization: `Bearer ${process.env.EXPO_PUBLIC_OPENAI_API_KEY}`,
         },
         body: JSON.stringify({
-          model: 'gpt-3.5-turbo',
-          messages: [
-            { role: 'system', content: 'Vous rédigez des courriers formels en français.' },
-            { role: 'user', content: generatePrompt() },
-          ],
-          max_tokens: 500,
+          prompt: generatePrompt(),
         }),
       });
 
@@ -95,7 +89,7 @@ export default function PreviewScreen() {
       }
 
       const data = await response.json();
-      setGeneratedLetter(data.choices[0].message.content.trim());
+      setGeneratedLetter(data.content.trim());
     } catch (error) {
       console.error('Error generating letter:', error);
       Alert.alert('Erreur', "La génération du courrier a échoué.");


### PR DESCRIPTION
## Summary
- add api/generate-letter.ts serverless function
- update preview screen to call the new API
- document new environment variables
- update `.env.example` with API URL and key

## Testing
- `npm run lint` *(fails: fetch failed)*

------
https://chatgpt.com/codex/tasks/task_e_684af2f7d020832081caa40d358f7e7d