### PR TITLE
Implement dynamic statistics on home screen

### DIFF
--- a/app/(tabs)/history.tsx
+++ b/app/(tabs)/history.tsx
@@ -1,60 +1,30 @@
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 import { View, Text, StyleSheet, ScrollView, TouchableOpacity } from 'react-native';
 import { Header } from '@/components/ui/Header';
 import { Card } from '@/components/ui/Card';
 import { Button } from '@/components/ui/Button';
 import { FileText, Download, Share2, Clock, Search } from 'lucide-react-native';
 import { Input } from '@/components/ui/Input';
+import { useHistory, HistoryItem } from '@/contexts/HistoryContext';
 
-interface HistoryItem {
-  id: string;
-  type: string;
-  title: string;
-  date: string;
-  recipient: string;
-  status: 'completed' | 'draft';
-}
-
-const historyData: HistoryItem[] = [
-  {
-    id: '1',
-    type: 'Résiliation',
-    title: 'Résiliation abonnement téléphonique',
-    date: '2024-01-15',
-    recipient: 'Orange',
-    status: 'completed',
-  },
-  {
-    id: '2',
-    type: 'Réclamation',
-    title: 'Réclamation service client',
-    date: '2024-01-10',
-    recipient: 'SNCF Connect',
-    status: 'completed',
-  },
-  {
-    id: '3',
-    type: 'Candidature',
-    title: 'Candidature développeur web',
-    date: '2024-01-08',
-    recipient: 'TechCorp SARL',
-    status: 'draft',
-  },
-];
 
 export default function HistoryScreen() {
+  const { history } = useHistory();
   const [searchQuery, setSearchQuery] = useState('');
-  const [filteredHistory, setFilteredHistory] = useState(historyData);
+  const [filteredHistory, setFilteredHistory] = useState<HistoryItem[]>(history);
 
   const handleSearch = (query: string) => {
     setSearchQuery(query);
-    const filtered = historyData.filter(item =>
-      item.title.toLowerCase().includes(query.toLowerCase()) ||
-      item.type.toLowerCase().includes(query.toLowerCase()) ||
-      item.recipient.toLowerCase().includes(query.toLowerCase())
+  };
+
+  useEffect(() => {
+    const filtered = history.filter(item =>
+      item.title.toLowerCase().includes(searchQuery.toLowerCase()) ||
+      item.type.toLowerCase().includes(searchQuery.toLowerCase()) ||
+      item.recipient.toLowerCase().includes(searchQuery.toLowerCase())
     );
     setFilteredHistory(filtered);
-  };
+  }, [searchQuery, history]);
 
   const formatDate = (dateString: string) => {
     const date = new Date(dateString);

--- a/app/(tabs)/index.tsx
+++ b/app/(tabs)/index.tsx
@@ -5,6 +5,7 @@ import { Header } from '@/components/ui/Header';
 import { Card } from '@/components/ui/Card';
 import { Button } from '@/components/ui/Button';
 import { FileText, Plus, Clock, TrendingUp, Star } from 'lucide-react-native';
+import { useHistory } from '@/contexts/HistoryContext';
 
 const quickActions = [
   {
@@ -25,13 +26,25 @@ const quickActions = [
   },
 ];
 
-const stats = [
-  { label: 'Courriers créés', value: '12', icon: FileText },
-  { label: 'Taux de succès', value: '98%', icon: TrendingUp },
-  { label: 'Note moyenne', value: '4.8', icon: Star },
-];
 
 export default function HomeScreen() {
+  const { history } = useHistory();
+  const completed = history.filter(h => h.status === 'completed');
+  const successRate = history.length
+    ? `${Math.round((completed.length / history.length) * 100)}%`
+    : '0%';
+  const averageRating = completed.length
+    ? (
+        completed.reduce((sum, item) => sum + (item.rating || 0), 0) /
+        completed.length
+      ).toFixed(1)
+    : 'N/A';
+  const stats = [
+    { label: 'Courriers créés', value: String(completed.length), icon: FileText },
+    { label: 'Taux de succès', value: successRate, icon: TrendingUp },
+    { label: 'Note moyenne', value: averageRating, icon: Star },
+  ];
+
   return (
     <View style={styles.container}>
       <Header 

--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -5,6 +5,7 @@ import { useFrameworkReady } from '@/hooks/useFrameworkReady';
 import { useFonts, Inter_400Regular, Inter_500Medium, Inter_600SemiBold, Inter_700Bold } from '@expo-google-fonts/inter';
 import * as SplashScreen from 'expo-splash-screen';
 import { ProfileProvider } from '@/contexts/ProfileContext';
+import { HistoryProvider } from '@/contexts/HistoryContext';
 
 SplashScreen.preventAutoHideAsync();
 
@@ -30,13 +31,15 @@ export default function RootLayout() {
 
   return (
     <ProfileProvider>
-      <>
-        <Stack screenOptions={{ headerShown: false }}>
-          <Stack.Screen name="(tabs)" options={{ headerShown: false }} />
-          <Stack.Screen name="+not-found" />
-        </Stack>
-        <StatusBar style="auto" />
-      </>
+      <HistoryProvider>
+        <>
+          <Stack screenOptions={{ headerShown: false }}>
+            <Stack.Screen name="(tabs)" options={{ headerShown: false }} />
+            <Stack.Screen name="+not-found" />
+          </Stack>
+          <StatusBar style="auto" />
+        </>
+      </HistoryProvider>
     </ProfileProvider>
   );
 }

--- a/contexts/HistoryContext.tsx
+++ b/contexts/HistoryContext.tsx
@@ -1,0 +1,62 @@
+import React, { createContext, useContext, useState } from 'react';
+
+export interface HistoryItem {
+  id: string;
+  type: string;
+  title: string;
+  date: string;
+  recipient: string;
+  status: 'completed' | 'draft';
+  rating?: number;
+}
+
+const defaultHistory: HistoryItem[] = [
+  {
+    id: '1',
+    type: 'Résiliation',
+    title: 'Résiliation abonnement téléphonique',
+    date: '2024-01-15',
+    recipient: 'Orange',
+    status: 'completed',
+    rating: 5,
+  },
+  {
+    id: '2',
+    type: 'Réclamation',
+    title: 'Réclamation service client',
+    date: '2024-01-10',
+    recipient: 'SNCF Connect',
+    status: 'completed',
+    rating: 4.5,
+  },
+  {
+    id: '3',
+    type: 'Candidature',
+    title: 'Candidature développeur web',
+    date: '2024-01-08',
+    recipient: 'TechCorp SARL',
+    status: 'draft',
+  },
+];
+
+interface HistoryContextProps {
+  history: HistoryItem[];
+  setHistory: (items: HistoryItem[]) => void;
+}
+
+const HistoryContext = createContext<HistoryContextProps>({
+  history: defaultHistory,
+  setHistory: () => {},
+});
+
+export const useHistory = () => useContext(HistoryContext);
+
+export const HistoryProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
+  const [history, setHistory] = useState<HistoryItem[]>(defaultHistory);
+
+  return (
+    <HistoryContext.Provider value={{ history, setHistory }}>
+      {children}
+    </HistoryContext.Provider>
+  );
+};

--- a/contexts/index.ts
+++ b/contexts/index.ts
@@ -1,1 +1,2 @@
 export * from './ProfileContext';
+export * from './HistoryContext';


### PR DESCRIPTION
## Summary
- add new `HistoryContext` to store letter history
- register the provider in the app layout
- use the context in History screen
- compute statistics from history in Home screen

## Testing
- `npm run lint` *(fails: needs expo)*

------
https://chatgpt.com/codex/tasks/task_e_684af3e26954832089888092b251e60b