### PR TITLE
Add profile photo support

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,10 @@ npm run dev
 
 The `dev` script launches the Expo development server. Follow the instructions in the terminal to open the app in a simulator, the Expo Go app, or a web browser.
 
+### Additional dependencies
+
+This project uses [`expo-image-picker`](https://docs.expo.dev/versions/latest/sdk/imagepicker/) so that users can select a profile photo from their device. The library is installed automatically via `npm install`.
+
 ## Serverless API configuration
 
 The preview screen now calls a serverless function (`api/generate-letter.ts`) which hides the OpenAI API key on the server. Configure the following environment variables:

--- a/app/(tabs)/index.tsx
+++ b/app/(tabs)/index.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { View, Text, StyleSheet, ScrollView, TouchableOpacity, Image } from 'react-native';
+import { useProfile } from '@/contexts/ProfileContext';
 import { router } from 'expo-router';
 import { Header } from '@/components/ui/Header';
 import { Card } from '@/components/ui/Card';
@@ -32,6 +33,7 @@ const stats = [
 ];
 
 export default function HomeScreen() {
+  const { profile } = useProfile();
   return (
     <View style={styles.container}>
       <Header 
@@ -48,8 +50,12 @@ export default function HomeScreen() {
                 Prêt à créer votre prochain courrier professionnel ?
               </Text>
             </View>
-            <Image 
-              source={{ uri: 'https://images.pexels.com/photos/3184360/pexels-photo-3184360.jpeg?auto=compress&cs=tinysrgb&w=400' }}
+            <Image
+              source={{
+                uri:
+                  profile.photoUri ||
+                  'https://images.pexels.com/photos/3184360/pexels-photo-3184360.jpeg?auto=compress&cs=tinysrgb&w=400',
+              }}
               style={styles.welcomeImage}
             />
           </View>

--- a/app/(tabs)/profile.tsx
+++ b/app/(tabs)/profile.tsx
@@ -1,5 +1,6 @@
 import React, { useState, useEffect } from 'react';
-import { View, Text, StyleSheet, ScrollView, Alert } from 'react-native';
+import { View, Text, StyleSheet, ScrollView, Alert, Image, Pressable } from 'react-native';
+import * as ImagePicker from 'expo-image-picker';
 import { Header } from '@/components/ui/Header';
 import { Card } from '@/components/ui/Card';
 import { Button } from '@/components/ui/Button';
@@ -32,6 +33,13 @@ export default function ProfileScreen() {
 
   const updateField = (field: keyof ProfileData, value: string) => {
     setEditData(prev => ({ ...prev, [field]: value }));
+  };
+
+  const pickImage = async () => {
+    const result = await ImagePicker.launchImageLibraryAsync();
+    if (!result.canceled && result.assets && result.assets.length > 0) {
+      setProfile({ ...profileData, photoUri: result.assets[0].uri });
+    }
   };
 
   const ProfileField = ({ icon, label, value, field }: {
@@ -69,9 +77,13 @@ export default function ProfileScreen() {
       <ScrollView style={styles.content} showsVerticalScrollIndicator={false}>
         <Card style={styles.avatarCard}>
           <View style={styles.avatarContainer}>
-            <View style={styles.avatar}>
-              <User size={40} color="#1e3a8a" />
-            </View>
+            <Pressable style={styles.avatar} onPress={pickImage}>
+              {profileData.photoUri ? (
+                <Image source={{ uri: profileData.photoUri }} style={styles.avatarImage} />
+              ) : (
+                <User size={40} color="#1e3a8a" />
+              )}
+            </Pressable>
             <Text style={styles.userName}>
               {profileData.firstName} {profileData.lastName}
             </Text>
@@ -233,6 +245,11 @@ const styles = StyleSheet.create({
     alignItems: 'center',
     justifyContent: 'center',
     marginBottom: 12,
+  },
+  avatarImage: {
+    width: 80,
+    height: 80,
+    borderRadius: 40,
   },
   userName: {
     fontSize: 24,

--- a/contexts/ProfileContext.tsx
+++ b/contexts/ProfileContext.tsx
@@ -10,6 +10,7 @@ export interface ProfileData {
   city: string;
   company?: string;
   position?: string;
+  photoUri?: string;
 }
 
 const defaultProfile: ProfileData = {
@@ -22,6 +23,7 @@ const defaultProfile: ProfileData = {
   city: 'Paris',
   company: 'Entreprise SARL',
   position: 'Développeur',
+  photoUri: undefined,
 };
 
 interface ProfileContextProps {

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,6 +21,7 @@
         "expo-constants": "~17.1.3",
         "expo-font": "~13.2.2",
         "expo-haptics": "~14.1.3",
+        "expo-image-picker": "^16.1.4",
         "expo-linear-gradient": "~14.1.3",
         "expo-linking": "~7.1.3",
         "expo-mail-composer": "^14.1.4",
@@ -2689,7 +2690,7 @@
       "version": "19.0.14",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.0.14.tgz",
       "integrity": "sha512-ixLZ7zG7j1fM0DijL9hDArwhwcCb4vqmePgwtV0GfnkHRSCUEv4LvzarcTdhoqgyMznUx/EhoTUv31CKZzkQlw==",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "csstype": "^3.0.2"
       }
@@ -3790,7 +3791,7 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
       "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
-      "dev": true
+      "devOptional": true
     },
     "node_modules/debug": {
       "version": "4.4.0",
@@ -4219,6 +4220,27 @@
       "version": "14.1.3",
       "resolved": "https://registry.npmjs.org/expo-haptics/-/expo-haptics-14.1.3.tgz",
       "integrity": "sha512-463Frhn8Lf3qG7I05MjPWRTo0EmcE7GXVzXzv+Mg/pPMo7QQCzzYheSYbrpFzJLfvDIKVqwnHZMauoVMD9/X0A==",
+      "peerDependencies": {
+        "expo": "*"
+      }
+    },
+    "node_modules/expo-image-loader": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/expo-image-loader/-/expo-image-loader-5.1.0.tgz",
+      "integrity": "sha512-sEBx3zDQIODWbB5JwzE7ZL5FJD+DK3LVLWBVJy6VzsqIA6nDEnSFnsnWyCfCTSvbGigMATs1lgkC2nz3Jpve1Q==",
+      "license": "MIT",
+      "peerDependencies": {
+        "expo": "*"
+      }
+    },
+    "node_modules/expo-image-picker": {
+      "version": "16.1.4",
+      "resolved": "https://registry.npmjs.org/expo-image-picker/-/expo-image-picker-16.1.4.tgz",
+      "integrity": "sha512-bTmmxtw1AohUT+HxEBn2vYwdeOrj1CLpMXKjvi9FKSoSbpcarT4xxI0z7YyGwDGHbrJqyyic3I9TTdP2J2b4YA==",
+      "license": "MIT",
+      "dependencies": {
+        "expo-image-loader": "~5.1.0"
+      },
       "peerDependencies": {
         "expo": "*"
       }

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "expo-constants": "~17.1.3",
     "expo-font": "~13.2.2",
     "expo-haptics": "~14.1.3",
+    "expo-image-picker": "^16.1.4",
     "expo-linear-gradient": "~14.1.3",
     "expo-linking": "~7.1.3",
     "expo-mail-composer": "^14.1.4",


### PR DESCRIPTION
## Summary
- extend profile data with optional `photoUri`
- install `expo-image-picker`
- allow selecting a profile photo
- show user's photo in welcome card
- document expo-image-picker in README

## Testing
- `npm run lint` *(fails: EnvHttpProxyAgent experimental & fetch failed)*

------
https://chatgpt.com/codex/tasks/task_e_684af70b3dcc8320be6c82402eae4ac3