### PR TITLE
Fix preview import and framework ready hook

### DIFF
--- a/app/(tabs)/create/preview.tsx
+++ b/app/(tabs)/create/preview.tsx
@@ -13,9 +13,6 @@ import * as Sharing from 'expo-sharing';
 import * as Clipboard from 'expo-clipboard';
 import * as MailComposer from 'expo-mail-composer';
 
-import { useProfile } from '@/contexts/ProfileContext';
-
-
 interface RecipientData {
   service: string;
   firstName: string;

--- a/hooks/useFrameworkReady.ts
+++ b/hooks/useFrameworkReady.ts
@@ -9,5 +9,5 @@ declare global {
 export function useFrameworkReady() {
   useEffect(() => {
     window.frameworkReady?.();
-  });
+  }, []);
 }


### PR DESCRIPTION
## Summary
- remove duplicate `useProfile` import from preview screen
- only run `useFrameworkReady` effect once

## Testing
- `npx expo lint` *(fails: `expo` not installed)*

------
https://chatgpt.com/codex/tasks/task_e_684af7cd159083209479cf2825f06c6e