### PR TITLE
Add profile photo support

### DIFF
--- a/app/(tabs)/index.tsx
+++ b/app/(tabs)/index.tsx
@@ -6,6 +6,7 @@ import { Card } from '@/components/ui/Card';
 import { Button } from '@/components/ui/Button';
 import { FileText, Plus, Clock, TrendingUp, Star } from 'lucide-react-native';
 import { useHistory } from '@/contexts/HistoryContext';
+import { useProfile } from '@/contexts/ProfileContext';
 
 const quickActions = [
   {
@@ -29,6 +30,7 @@ const quickActions = [
 
 export default function HomeScreen() {
   const { history } = useHistory();
+  const { profile } = useProfile();
   const completed = history.filter(h => h.status === 'completed');
   const successRate = history.length
     ? `${Math.round((completed.length / history.length) * 100)}%`
@@ -56,13 +58,19 @@ export default function HomeScreen() {
         <Card style={styles.welcomeCard}>
           <View style={styles.welcomeContent}>
             <View style={styles.welcomeText}>
-              <Text style={styles.welcomeTitle}>Bonjour Jean ! 👋</Text>
+              <Text style={styles.welcomeTitle}>
+                Bonjour {profile.firstName} ! 👋
+              </Text>
               <Text style={styles.welcomeSubtitle}>
                 Prêt à créer votre prochain courrier professionnel ?
               </Text>
             </View>
-            <Image 
-              source={{ uri: 'https://images.pexels.com/photos/3184360/pexels-photo-3184360.jpeg?auto=compress&cs=tinysrgb&w=400' }}
+            <Image
+              source={{
+                uri:
+                  profile.photoUri ||
+                  'https://images.pexels.com/photos/3184360/pexels-photo-3184360.jpeg?auto=compress&cs=tinysrgb&w=400',
+              }}
               style={styles.welcomeImage}
             />
           </View>

--- a/app/(tabs)/profile.tsx
+++ b/app/(tabs)/profile.tsx
@@ -1,5 +1,6 @@
 import React, { useState, useEffect } from 'react';
-import { View, Text, StyleSheet, ScrollView, Alert } from 'react-native';
+import { View, Text, StyleSheet, ScrollView, Alert, Image } from 'react-native';
+import * as ImagePicker from 'expo-image-picker';
 import { Header } from '@/components/ui/Header';
 import { Card } from '@/components/ui/Card';
 import { Button } from '@/components/ui/Button';
@@ -32,6 +33,25 @@ export default function ProfileScreen() {
 
   const updateField = (field: keyof ProfileData, value: string) => {
     setEditData(prev => ({ ...prev, [field]: value }));
+  };
+
+  const handlePickImage = async () => {
+    const permission = await ImagePicker.requestMediaLibraryPermissionsAsync();
+    if (!permission.granted) {
+      Alert.alert(
+        'Permission requise',
+        "L'autorisation d'accéder à la galerie est nécessaire."
+      );
+      return;
+    }
+    const result = await ImagePicker.launchImageLibraryAsync({
+      mediaTypes: ImagePicker.MediaTypeOptions.Images,
+      quality: 0.7,
+    });
+    if (!result.canceled) {
+      const uri = result.assets[0].uri;
+      setEditData(prev => ({ ...prev, photoUri: uri }));
+    }
   };
 
   const ProfileField = ({ icon, label, value, field }: {
@@ -70,14 +90,27 @@ export default function ProfileScreen() {
         <Card style={styles.avatarCard}>
           <View style={styles.avatarContainer}>
             <View style={styles.avatar}>
-              <User size={40} color="#1e3a8a" />
+              {(isEditing ? editData.photoUri : profileData.photoUri) ? (
+                <Image
+                  source={{ uri: isEditing ? editData.photoUri : profileData.photoUri }}
+                  style={styles.avatarImage}
+                />
+              ) : (
+                <User size={40} color="#1e3a8a" />
+              )}
             </View>
+            {isEditing && (
+              <Button title="Changer la photo" onPress={handlePickImage} size="small" style={styles.photoButton} />
+            )}
             <Text style={styles.userName}>
-              {profileData.firstName} {profileData.lastName}
+              {isEditing ? editData.firstName : profileData.firstName}{' '}
+              {isEditing ? editData.lastName : profileData.lastName}
             </Text>
-            {profileData.position && profileData.company && (
+            {(isEditing ? editData.position : profileData.position) &&
+              (isEditing ? editData.company : profileData.company) && (
               <Text style={styles.userRole}>
-                {profileData.position} chez {profileData.company}
+                {isEditing ? editData.position : profileData.position} chez{' '}
+                {isEditing ? editData.company : profileData.company}
               </Text>
             )}
           </View>
@@ -232,6 +265,14 @@ const styles = StyleSheet.create({
     backgroundColor: '#f0f9ff',
     alignItems: 'center',
     justifyContent: 'center',
+    marginBottom: 12,
+  },
+  avatarImage: {
+    width: 80,
+    height: 80,
+    borderRadius: 40,
+  },
+  photoButton: {
     marginBottom: 12,
   },
   userName: {

--- a/contexts/ProfileContext.tsx
+++ b/contexts/ProfileContext.tsx
@@ -10,6 +10,7 @@ export interface ProfileData {
   city: string;
   company?: string;
   position?: string;
+  photoUri?: string;
 }
 
 const defaultProfile: ProfileData = {
@@ -22,6 +23,7 @@ const defaultProfile: ProfileData = {
   city: 'Paris',
   company: 'Entreprise SARL',
   position: 'Développeur',
+  photoUri: '',
 };
 
 interface ProfileContextProps {

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,6 +21,7 @@
         "expo-constants": "~17.1.3",
         "expo-font": "~13.2.2",
         "expo-haptics": "~14.1.3",
+        "expo-image-picker": "16.1.4",
         "expo-linear-gradient": "~14.1.3",
         "expo-linking": "~7.1.3",
         "expo-mail-composer": "^14.1.4",
@@ -4219,6 +4220,27 @@
       "version": "14.1.3",
       "resolved": "https://registry.npmjs.org/expo-haptics/-/expo-haptics-14.1.3.tgz",
       "integrity": "sha512-463Frhn8Lf3qG7I05MjPWRTo0EmcE7GXVzXzv+Mg/pPMo7QQCzzYheSYbrpFzJLfvDIKVqwnHZMauoVMD9/X0A==",
+      "peerDependencies": {
+        "expo": "*"
+      }
+    },
+    "node_modules/expo-image-loader": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/expo-image-loader/-/expo-image-loader-5.1.0.tgz",
+      "integrity": "sha512-sEBx3zDQIODWbB5JwzE7ZL5FJD+DK3LVLWBVJy6VzsqIA6nDEnSFnsnWyCfCTSvbGigMATs1lgkC2nz3Jpve1Q==",
+      "license": "MIT",
+      "peerDependencies": {
+        "expo": "*"
+      }
+    },
+    "node_modules/expo-image-picker": {
+      "version": "16.1.4",
+      "resolved": "https://registry.npmjs.org/expo-image-picker/-/expo-image-picker-16.1.4.tgz",
+      "integrity": "sha512-bTmmxtw1AohUT+HxEBn2vYwdeOrj1CLpMXKjvi9FKSoSbpcarT4xxI0z7YyGwDGHbrJqyyic3I9TTdP2J2b4YA==",
+      "license": "MIT",
+      "dependencies": {
+        "expo-image-loader": "~5.1.0"
+      },
       "peerDependencies": {
         "expo": "*"
       }

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "expo": "^53.0.0",
     "expo-blur": "~14.1.3",
     "expo-camera": "~16.1.5",
+    "expo-image-picker": "16.1.4",
     "expo-clipboard": "^7.1.4",
     "expo-constants": "~17.1.3",
     "expo-font": "~13.2.2",


### PR DESCRIPTION
## Summary
- enable profile photo field in profile context
- allow users to pick a photo in the profile screen
- display user's photo and name on the home screen
- add expo-image-picker dependency

## Testing
- `npm install --legacy-peer-deps`
- `npm run lint` *(fails: fetch failed to api.expo.dev)*

------
https://chatgpt.com/codex/tasks/task_e_684bec76a3808320b5a492cbc5177a6a