### PR TITLE
Implement support menu navigation

### DIFF
--- a/app/(tabs)/settings/_layout.tsx
+++ b/app/(tabs)/settings/_layout.tsx
@@ -5,6 +5,9 @@ export default function SettingsLayout() {
     <Stack screenOptions={{ headerShown: false }}>
       <Stack.Screen name="index" />
       <Stack.Screen name="privacy" />
+      <Stack.Screen name="help" />
+      <Stack.Screen name="contact" />
+      <Stack.Screen name="rate" />
     </Stack>
   );
 }

--- a/app/(tabs)/settings/contact.tsx
+++ b/app/(tabs)/settings/contact.tsx
@@ -1,0 +1,91 @@
+import React from 'react';
+import { View, Text, StyleSheet, ScrollView, TouchableOpacity, Alert } from 'react-native';
+import { Header } from '@/components/ui/Header';
+import { Card } from '@/components/ui/Card';
+import { Button } from '@/components/ui/Button';
+import { ArrowLeft } from 'lucide-react-native';
+import { router } from 'expo-router';
+import * as MailComposer from 'expo-mail-composer';
+
+export default function ContactScreen() {
+  const handleBack = () => {
+    router.back();
+  };
+
+  const handleContact = async () => {
+    try {
+      const available = await MailComposer.isAvailableAsync();
+      if (!available) {
+        Alert.alert('Erreur', "Aucune application de messagerie n'est disponible");
+        return;
+      }
+      await MailComposer.composeAsync({
+        recipients: ['support@example.com'],
+        subject: 'Assistance Assistant Courrier',
+      });
+    } catch (error) {
+      console.error('Contact error', error);
+      Alert.alert('Erreur', "Impossible d'ouvrir l'application de messagerie");
+    }
+  };
+
+  return (
+    <View style={styles.container}>
+      <Header
+        title="Nous contacter"
+        subtitle="Support technique et questions"
+      />
+
+      <ScrollView style={styles.content} showsVerticalScrollIndicator={false}>
+        <TouchableOpacity style={styles.backButton} onPress={handleBack}>
+          <ArrowLeft size={20} color="#3b82f6" />
+          <Text style={styles.backText}>Retour</Text>
+        </TouchableOpacity>
+
+        <Card style={styles.textCard}>
+          <Text style={styles.paragraph}>
+            Si vous rencontrez un problème ou avez une question, vous pouvez nous envoyer un email.
+          </Text>
+          <Button title="Envoyer un email" onPress={handleContact} style={{ marginTop: 16 }} />
+        </Card>
+
+        <View style={styles.bottomSpacing} />
+      </ScrollView>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    backgroundColor: '#f8fafc',
+  },
+  content: {
+    flex: 1,
+    paddingHorizontal: 20,
+  },
+  backButton: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    marginTop: 20,
+    marginBottom: 16,
+  },
+  backText: {
+    fontSize: 16,
+    fontFamily: 'Inter-Medium',
+    color: '#3b82f6',
+    marginLeft: 8,
+  },
+  textCard: {
+    marginBottom: 16,
+  },
+  paragraph: {
+    fontSize: 16,
+    fontFamily: 'Inter-Regular',
+    color: '#1e293b',
+    lineHeight: 24,
+  },
+  bottomSpacing: {
+    height: 40,
+  },
+});

--- a/app/(tabs)/settings/help.tsx
+++ b/app/(tabs)/settings/help.tsx
@@ -1,0 +1,71 @@
+import React from 'react';
+import { View, Text, StyleSheet, ScrollView, TouchableOpacity } from 'react-native';
+import { Header } from '@/components/ui/Header';
+import { Card } from '@/components/ui/Card';
+import { ArrowLeft } from 'lucide-react-native';
+import { router } from 'expo-router';
+
+export default function HelpScreen() {
+  const handleBack = () => {
+    router.back();
+  };
+
+  return (
+    <View style={styles.container}>
+      <Header
+        title="Centre d'aide"
+        subtitle="FAQ et guides d'utilisation"
+      />
+
+      <ScrollView style={styles.content} showsVerticalScrollIndicator={false}>
+        <TouchableOpacity style={styles.backButton} onPress={handleBack}>
+          <ArrowLeft size={20} color="#3b82f6" />
+          <Text style={styles.backText}>Retour</Text>
+        </TouchableOpacity>
+
+        <Card style={styles.textCard}>
+          <Text style={styles.paragraph}>
+            Retrouvez ici des conseils et des explications pour profiter pleinement de l'application.
+          </Text>
+        </Card>
+
+        <View style={styles.bottomSpacing} />
+      </ScrollView>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    backgroundColor: '#f8fafc',
+  },
+  content: {
+    flex: 1,
+    paddingHorizontal: 20,
+  },
+  backButton: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    marginTop: 20,
+    marginBottom: 16,
+  },
+  backText: {
+    fontSize: 16,
+    fontFamily: 'Inter-Medium',
+    color: '#3b82f6',
+    marginLeft: 8,
+  },
+  textCard: {
+    marginBottom: 16,
+  },
+  paragraph: {
+    fontSize: 16,
+    fontFamily: 'Inter-Regular',
+    color: '#1e293b',
+    lineHeight: 24,
+  },
+  bottomSpacing: {
+    height: 40,
+  },
+});

--- a/app/(tabs)/settings/index.tsx
+++ b/app/(tabs)/settings/index.tsx
@@ -102,7 +102,7 @@ export default function SettingsScreen() {
       subtitle: 'FAQ et guides d\'utilisation',
       icon: <HelpCircle size={20} color="#3b82f6" />,
       type: 'navigation',
-      onPress: () => console.log('Navigation vers aide'),
+      onPress: () => router.push('/settings/help'),
     },
     {
       id: 'contact',
@@ -110,7 +110,7 @@ export default function SettingsScreen() {
       subtitle: 'Support technique et questions',
       icon: <Smartphone size={20} color="#3b82f6" />,
       type: 'navigation',
-      onPress: () => console.log('Navigation vers contact'),
+      onPress: () => router.push('/settings/contact'),
     },
     {
       id: 'rate',
@@ -118,7 +118,7 @@ export default function SettingsScreen() {
       subtitle: 'Votre avis nous aide à nous améliorer',
       icon: <Star size={20} color="#3b82f6" />,
       type: 'navigation',
-      onPress: () => console.log('Navigation vers notation'),
+      onPress: () => router.push('/settings/rate'),
     },
   ];
 

--- a/app/(tabs)/settings/rate.tsx
+++ b/app/(tabs)/settings/rate.tsx
@@ -1,0 +1,88 @@
+import React from 'react';
+import { View, Text, StyleSheet, ScrollView, TouchableOpacity, Linking, Alert } from 'react-native';
+import { Header } from '@/components/ui/Header';
+import { Card } from '@/components/ui/Card';
+import { Button } from '@/components/ui/Button';
+import { ArrowLeft } from 'lucide-react-native';
+import { router } from 'expo-router';
+
+export default function RateScreen() {
+  const handleBack = () => {
+    router.back();
+  };
+
+  const handleRate = async () => {
+    try {
+      const url = 'https://example.com/rate';
+      const supported = await Linking.canOpenURL(url);
+      if (supported) {
+        await Linking.openURL(url);
+      } else {
+        Alert.alert('Erreur', "Impossible d'ouvrir le lien de notation");
+      }
+    } catch (error) {
+      console.error('Rate error', error);
+      Alert.alert('Erreur', "Impossible d'ouvrir le lien de notation");
+    }
+  };
+
+  return (
+    <View style={styles.container}>
+      <Header
+        title="Noter l'application"
+        subtitle="Votre avis nous aide à nous améliorer"
+      />
+
+      <ScrollView style={styles.content} showsVerticalScrollIndicator={false}>
+        <TouchableOpacity style={styles.backButton} onPress={handleBack}>
+          <ArrowLeft size={20} color="#3b82f6" />
+          <Text style={styles.backText}>Retour</Text>
+        </TouchableOpacity>
+
+        <Card style={styles.textCard}>
+          <Text style={styles.paragraph}>
+            Nous serions ravis de connaître votre opinion. N'hésitez pas à noter l'application sur la boutique.
+          </Text>
+          <Button title="Noter l'application" onPress={handleRate} style={{ marginTop: 16 }} />
+        </Card>
+
+        <View style={styles.bottomSpacing} />
+      </ScrollView>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    backgroundColor: '#f8fafc',
+  },
+  content: {
+    flex: 1,
+    paddingHorizontal: 20,
+  },
+  backButton: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    marginTop: 20,
+    marginBottom: 16,
+  },
+  backText: {
+    fontSize: 16,
+    fontFamily: 'Inter-Medium',
+    color: '#3b82f6',
+    marginLeft: 8,
+  },
+  textCard: {
+    marginBottom: 16,
+  },
+  paragraph: {
+    fontSize: 16,
+    fontFamily: 'Inter-Regular',
+    color: '#1e293b',
+    lineHeight: 24,
+  },
+  bottomSpacing: {
+    height: 40,
+  },
+});


### PR DESCRIPTION
## Summary
- add help, contact and rate screens
- hook up support menu entries to the new screens
- register support screens in the settings layout

## Testing
- `npm run lint` *(fails: expo command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684c5758629c8320952b648cbcedfb80