### PR TITLE
Fix create button in history screen

### DIFF
--- a/app/(tabs)/history.tsx
+++ b/app/(tabs)/history.tsx
@@ -6,6 +6,7 @@ import { Button } from '@/components/ui/Button';
 import { FileText, Download, Share2, Clock, Search, Copy } from 'lucide-react-native';
 import { Input } from '@/components/ui/Input';
 import { useHistory, HistoryItem } from '@/contexts/HistoryContext';
+import { router } from 'expo-router';
 import * as Print from 'expo-print';
 import * as FileSystem from 'expo-file-system';
 import * as Sharing from 'expo-sharing';
@@ -124,7 +125,7 @@ export default function HistoryScreen() {
             {!searchQuery && (
               <Button
                 title="Créer mon premier courrier"
-                onPress={() => {/* Navigation vers création */}}
+                onPress={() => router.push('/(tabs)/create')}
                 style={styles.createButton}
               />
             )}


### PR DESCRIPTION
## Summary
- enable navigation from History screen to the letter creation flow

## Testing
- `npm run lint` *(fails: fetch failed to api.expo.dev)*

------
https://chatgpt.com/codex/tasks/task_e_684d27cfb56083209c8acec99404fef4