### PR TITLE
Fix PDF generation for old history entries

### DIFF
--- a/app/(tabs)/history.tsx
+++ b/app/(tabs)/history.tsx
@@ -48,7 +48,10 @@ export default function HistoryScreen() {
     return status === 'completed' ? 'Terminé' : 'Brouillon';
   };
 
-  const generatePdf = async (content: string): Promise<string> => {
+  const generatePdf = async (content?: string): Promise<string> => {
+    if (!content) {
+      throw new Error('empty content');
+    }
     const html = `\n      <html>\n        <head><meta charset="utf-8" /></head>\n        <body style="font-family:sans-serif; white-space:pre-wrap;">${content.replace(/\n/g, '<br/>')}</body>\n      </html>`;
 
     if (Platform.OS === 'web') {
@@ -72,6 +75,10 @@ export default function HistoryScreen() {
   };
 
   const handleDownload = async (item: HistoryItem) => {
+    if (!item.content) {
+      Alert.alert('Erreur', 'Ce courrier ne contient pas de texte.');
+      return;
+    }
     try {
       const path = await generatePdf(item.content);
       Alert.alert('Téléchargement', `Fichier enregistré: ${path}`);
@@ -82,6 +89,10 @@ export default function HistoryScreen() {
   };
 
   const handleShare = async (item: HistoryItem) => {
+    if (!item.content) {
+      Alert.alert('Erreur', 'Ce courrier ne contient pas de texte.');
+      return;
+    }
     try {
       const path = await generatePdf(item.content);
       await Sharing.shareAsync(path);
@@ -92,6 +103,10 @@ export default function HistoryScreen() {
   };
 
   const handleCopy = (item: HistoryItem) => {
+    if (!item.content) {
+      Alert.alert('Erreur', 'Ce courrier ne contient pas de texte.');
+      return;
+    }
     Clipboard.setStringAsync(item.content);
     Alert.alert('Copié', 'Le texte a été copié dans le presse-papiers');
   };

--- a/contexts/HistoryContext.tsx
+++ b/contexts/HistoryContext.tsx
@@ -7,7 +7,7 @@ export interface HistoryItem {
   title: string;
   date: string;
   recipient: string;
-  content: string;
+  content?: string;
   status: 'completed' | 'draft';
   rating?: number;
 }


### PR DESCRIPTION
## Summary
- allow history items without `content`
- guard actions on history screen when content is missing

## Testing
- `npm run lint` *(fails: expo CLI network access blocked)*

------
https://chatgpt.com/codex/tasks/task_e_684d2d8bed4083209c6c2d6555792b08