### PR TITLE
Fix start script and package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "dev": "EXPO_NO_TELEMETRY=1 expo start",
     "build:web": "expo export --platform web",
     "lint": "npx expo lint",
-    "start": "node server.js"
+    "start": "expo start"
   },
   "dependencies": {
     "@expo-google-fonts/inter": "^0.2.3",
@@ -36,7 +36,7 @@
     "expo-system-ui": "~5.0.5",
     "expo-web-browser": "~14.1.5",
     "lucide-react-native": "^0.480.0",
-    "react": "18.2.0"
+    "react": "18.2.0",
     "react-dom": "19.0.0",
     "react-native": "0.79.1",
     "react-native-gesture-handler": "~2.24.0",


### PR DESCRIPTION
## Summary
- use `expo start` for the default npm start command
- fix package.json syntax

## Testing
- `npm run lint` *(fails: EnvHttpProxyAgent is experimental, fetch failed)*

------
https://chatgpt.com/codex/tasks/task_e_684d5a6f932083208ff1d17bc418c709