### PR TITLE
Remove tracked environment file

### DIFF
--- a/.env
+++ b/.env
@@ -1,7 +1,0 @@
-# API key used by the backend service. Replace with your actual key.
-OPENAI_API_KEY=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
-
-# Address of the Express backend.
-# The server listens on port 3001 by default.
-EXPO_PUBLIC_API_URL=http://192.168.1.51:3001
-EXPO_PUBLIC_SERVER_URL=http://192.168.1.51:3001

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,12 @@
+# Ignore local environment variables
+.env
+
+# Node modules and Expo build output
+node_modules/
+.expo/
+
+# Logs
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+

--- a/README.md
+++ b/README.md
@@ -13,8 +13,12 @@ Install dependencies and start the development server:
 
 ```bash
 npm install
+cp .env.example .env # create your local environment file
 npm run dev
 ```
+
+Copy `.env.example` to `.env` and add your own secrets before running the app. The
+`.env` file is ignored by Git.
 
 The `dev` script launches the Expo development server. Follow the instructions in the terminal to open the app in a simulator, the Expo Go app, or a web browser.
 


### PR DESCRIPTION
## Summary
- delete the committed `.env` file
- add `.env` to `.gitignore`
- document using `.env.example` in setup instructions

## Testing
- `npm run lint` *(fails: `Invalid package.json`)*

------
https://chatgpt.com/codex/tasks/task_e_684d5a6f33e0832092cac0d072fd8296