### PR TITLE
Fix missing comma in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "expo-system-ui": "~5.0.5",
     "expo-web-browser": "~14.1.5",
     "lucide-react-native": "^0.480.0",
-    "react": "18.2.0"
+    "react": "18.2.0",
     "react-dom": "19.0.0",
     "react-native": "0.79.1",
     "react-native-gesture-handler": "~2.24.0",


### PR DESCRIPTION
## Summary
- fix JSON format by adding comma after `react` dependency

## Testing
- `jq '.' package.json`

------
https://chatgpt.com/codex/tasks/task_e_684d5a6e7e308320843efbe22714f7d2