### PR TITLE
Add congé letter type

### DIFF
--- a/constants/letterTypes.ts
+++ b/constants/letterTypes.ts
@@ -289,6 +289,48 @@ export const LETTER_TYPES: LetterTypeInfo[] = [
     ],
   },
   {
+    type: 'conge',
+    title: 'Demande de congé',
+    description: 'Demander un congé ou une absence prolongée',
+    icon: 'Plane',
+    color: '#0d9488',
+    fields: [
+      {
+        key: 'leaveType',
+        label: 'Type de congé',
+        type: 'select',
+        required: true,
+        options: ['Congé payé', 'Congé sans solde', 'Maladie', 'Maternité/Paternité', 'Autre'],
+      },
+      {
+        key: 'startDate',
+        label: 'Date de début',
+        type: 'date',
+        required: true,
+      },
+      {
+        key: 'endDate',
+        label: 'Date de fin',
+        type: 'date',
+        required: true,
+      },
+      {
+        key: 'reason',
+        label: 'Motif',
+        type: 'textarea',
+        required: false,
+        placeholder: 'Indiquez le motif du congé...'
+      },
+      {
+        key: 'contactDuringLeave',
+        label: 'Contact pendant le congé',
+        type: 'text',
+        required: false,
+        placeholder: 'Email ou téléphone en cas d\'urgence',
+      },
+    ],
+  },
+  {
     type: 'administrative',
     title: 'Démarche administrative',
     description: 'Courrier pour administrations et services publics',

--- a/services/letterService.ts
+++ b/services/letterService.ts
@@ -109,6 +109,22 @@ class LetterService {
           updatedAt: new Date('2024-01-10'),
           status: 'completed',
         },
+        {
+          id: '3',
+          type: 'conge',
+          title: 'Demande de congé annuel',
+          content: 'Objet : Demande de congé du 01/08 au 15/08...',
+          recipient: {
+            company: 'ACME Corp',
+            service: 'Ressources Humaines',
+            address: '50 Rue Exemple',
+            postalCode: '69000',
+            city: 'Lyon',
+          },
+          createdAt: new Date('2024-01-05'),
+          updatedAt: new Date('2024-01-05'),
+          status: 'completed',
+        },
       ];
     } catch (error) {
       console.error('Erreur chargement courriers:', error);

--- a/types/letter.ts
+++ b/types/letter.ts
@@ -40,6 +40,7 @@ export type LetterType =
   | 'remerciement'
   | 'motivation'
   | 'excuse'
+  | 'conge'
   | 'administrative'
   | 'commercial'
   | 'autres';


### PR DESCRIPTION
## Summary
- extend `LetterType` union with `conge`
- define congé fields in `LETTER_TYPES`
- include sample congé letter in demo data

## Testing
- `npm run lint` *(fails: fetch failed)*

------
https://chatgpt.com/codex/tasks/task_e_684e8a12860483209184111f16810104