### PR TITLE
Improve reset button style

### DIFF
--- a/app/(tabs)/create.tsx
+++ b/app/(tabs)/create.tsx
@@ -130,8 +130,8 @@ export default function CreateScreen() {
                   title="Réinitialiser"
                   icon={Send}
                   onPress={resetForm}
-                  variant="outline"
-                  size="medium"
+                  variant="primary"
+                  size="large"
                 />
               </View>
             </View>


### PR DESCRIPTION
## Summary
- use the primary variant for the reset button on the create page
- use large size for better matching with the main button

## Testing
- `npm run lint` *(fails: expo not found)*

------
https://chatgpt.com/codex/tasks/task_e_684e90d176e08320b3be2edeac2537f6