### PR TITLE
Add loading overlay for letter generation

### DIFF
--- a/app/(tabs)/create.tsx
+++ b/app/(tabs)/create.tsx
@@ -5,6 +5,7 @@ import LetterTypeSelector from '@/components/LetterTypeSelector';
 import RecipientForm from '@/components/RecipientForm';
 import LetterFieldsForm from '@/components/LetterFieldsForm';
 import ActionButton from '@/components/ActionButton';
+import LoadingOverlay from '@/components/LoadingOverlay';
 import { LetterType, Recipient, UserProfile } from '@/types/letter';
 import { letterService } from '@/services/letterService';
 import { FileText, Send } from 'lucide-react-native';
@@ -138,6 +139,7 @@ export default function CreateScreen() {
           </>
         )}
       </ScrollView>
+      {isGenerating && <LoadingOverlay />}
     </View>
   );
 }

--- a/components/LoadingOverlay.tsx
+++ b/components/LoadingOverlay.tsx
@@ -1,0 +1,20 @@
+import React from 'react';
+import { View, ActivityIndicator, StyleSheet } from 'react-native';
+
+export default function LoadingOverlay() {
+  return (
+    <View style={styles.overlay} pointerEvents="auto">
+      <ActivityIndicator size="large" color="#1e40af" />
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  overlay: {
+    ...StyleSheet.absoluteFillObject,
+    backgroundColor: 'rgba(255, 255, 255, 0.8)',
+    alignItems: 'center',
+    justifyContent: 'center',
+    zIndex: 999,
+  },
+});


### PR DESCRIPTION
## Summary
- add a `LoadingOverlay` component with `ActivityIndicator`
- show overlay while letter generation is in progress

## Testing
- `npm run lint` *(fails: fetch failed - api.expo.dev blocked)*

------
https://chatgpt.com/codex/tasks/task_e_684e926fd2c08320ba4662475fd1f5c8