### PR TITLE
Add API_BASE_URL env config

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,1 @@
+API_BASE_URL=https://assistant-backend-yrbx.onrender.com

--- a/README.md
+++ b/README.md
@@ -14,6 +14,18 @@ npm install
 npm run dev
 ```
 
+## Configuration
+
+Set the `API_BASE_URL` environment variable to configure the backend URL. You
+can copy `.env.example` and adjust the value:
+
+```bash
+cp .env.example .env
+```
+
+If the variable is not provided, the app defaults to
+`https://assistant-backend-yrbx.onrender.com`.
+
 ## Features
 
 - Create letters

--- a/services/letterService.ts
+++ b/services/letterService.ts
@@ -1,6 +1,7 @@
 import { Letter, LetterRequest, UserProfile, Statistics } from '@/types/letter';
 
-const API_BASE_URL = 'https://assistant-backend-yrbx.onrender.com';
+const API_BASE_URL =
+  process.env.API_BASE_URL ?? 'https://assistant-backend-yrbx.onrender.com';
 
 class LetterService {
   async generateLetter(request: LetterRequest): Promise<string> {


### PR DESCRIPTION
## Summary
- use `process.env.API_BASE_URL` with a default value
- document the new variable in README
- provide `.env.example`

## Testing
- `npm run lint` *(fails: fetch to api.expo.dev blocked)*

------
https://chatgpt.com/codex/tasks/task_e_684e92742b2483208c6869eadf31e607