### PR TITLE
Implement share functionality

### DIFF
--- a/app/letter-preview.tsx
+++ b/app/letter-preview.tsx
@@ -7,6 +7,7 @@ import {
   TouchableOpacity,
   Alert,
   Linking,
+  Share,
 } from 'react-native';
 import { useLocalSearchParams, router } from 'expo-router';
 import Header from '@/components/Header';
@@ -26,9 +27,9 @@ export default function LetterPreviewScreen() {
   const { content } = useLocalSearchParams<{ content?: string }>();
 
   const handleShare = async () => {
+    if (!content) return;
     try {
-      // En production, implémenter le partage natif
-      Alert.alert('Partage', 'Fonctionnalité de partage à implémenter');
+      await Share.share({ message: content });
     } catch (error) {
       Alert.alert('Erreur', 'Impossible de partager le courrier');
     }

--- a/components/LetterCard.tsx
+++ b/components/LetterCard.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
-import { View, Text, StyleSheet, TouchableOpacity, Alert } from 'react-native';
-import { Share, FileDown, Trash2, Eye } from 'lucide-react-native';
+import { View, Text, StyleSheet, TouchableOpacity, Alert, Share } from 'react-native';
+import { Share as ShareIcon, FileDown, Trash2, Eye } from 'lucide-react-native';
 import * as Print from 'expo-print';
 import * as FileSystem from 'expo-file-system';
 import * as Sharing from 'expo-sharing';
@@ -18,8 +18,7 @@ export default function LetterCard({ letter, onDelete }: LetterCardProps) {
   
   const handleShare = async () => {
     try {
-      // En production, implémenter le partage natif
-      Alert.alert('Partage', 'Fonctionnalité de partage à implémenter');
+      await Share.share({ message: letter.content });
     } catch (error) {
       Alert.alert('Erreur', 'Impossible de partager le courrier');
     }
@@ -82,7 +81,7 @@ export default function LetterCard({ letter, onDelete }: LetterCardProps) {
         </TouchableOpacity>
         
         <TouchableOpacity style={styles.actionButton} onPress={handleShare}>
-          <Share size={18} color="#6b7280" />
+          <ShareIcon size={18} color="#6b7280" />
         </TouchableOpacity>
         
         <TouchableOpacity style={styles.actionButton} onPress={handleDownload}>


### PR DESCRIPTION
## Summary
- enable text sharing from history and preview screens

## Testing
- `npm run lint` *(fails: fetch failed)*

------
https://chatgpt.com/codex/tasks/task_e_684e923d5c5483208b0415a6ec84c33a