### PR TITLE
Add back navigation support

### DIFF
--- a/app/letter-preview.tsx
+++ b/app/letter-preview.tsx
@@ -56,7 +56,11 @@ export default function LetterPreviewScreen() {
 
   return (
     <View style={styles.container}>
-      <Header title="Prévisualisation" subtitle="Aperçu du courrier généré" />
+      <Header
+        title="Prévisualisation"
+        subtitle="Aperçu du courrier généré"
+        showBack
+      />
 
       {!content ? (
         <EmptyState

--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -1,19 +1,31 @@
 import React from 'react';
-import { View, Text, StyleSheet, Platform } from 'react-native';
+import { View, Text, StyleSheet, Platform, TouchableOpacity } from 'react-native';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
+import { ArrowLeft } from 'lucide-react-native';
+import { router } from 'expo-router';
 
 interface HeaderProps {
   title: string;
   subtitle?: string;
+  showBack?: boolean;
 }
 
-export default function Header({ title, subtitle }: HeaderProps) {
+export default function Header({ title, subtitle, showBack }: HeaderProps) {
   const insets = useSafeAreaInsets();
+
+  const shouldShowBack = showBack || router.canGoBack();
 
   return (
     <View style={[styles.header, { paddingTop: insets.top }]}>
       <View style={styles.content}>
-        <Text style={styles.title}>{title}</Text>
+        <View style={styles.titleRow}>
+          {shouldShowBack && (
+            <TouchableOpacity onPress={() => router.back()} style={styles.backButton}>
+              <ArrowLeft size={24} color="#ffffff" />
+            </TouchableOpacity>
+          )}
+          <Text style={styles.title}>{title}</Text>
+        </View>
         {subtitle && <Text style={styles.subtitle}>{subtitle}</Text>}
       </View>
     </View>
@@ -29,11 +41,19 @@ const styles = StyleSheet.create({
     paddingHorizontal: 20,
     paddingTop: 16,
   },
+  titleRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    marginBottom: 4,
+  },
+  backButton: {
+    marginRight: 8,
+    padding: 4,
+  },
   title: {
     fontSize: 28,
     fontFamily: 'Roboto-Bold',
     color: '#ffffff',
-    marginBottom: 4,
   },
   subtitle: {
     fontSize: 16,


### PR DESCRIPTION
## Summary
- enable optional back button in `Header`
- show back arrow when previewing a letter

## Testing
- `npm run lint` *(fails: fetch failed)*

------
https://chatgpt.com/codex/tasks/task_e_684eec098ae8832095dac7331880e479