### PR TITLE
Fix cancel button color in profile settings

### DIFF
--- a/components/ProfileSection.tsx
+++ b/components/ProfileSection.tsx
@@ -195,7 +195,6 @@ export default function ProfileSection({ profile, onUpdateProfile, loading }: Pr
             <ActionButton
               title="Annuler"
               onPress={handleCancel}
-              variant="outline"
               size="medium"
             />
           </View>


### PR DESCRIPTION
## Summary
- remove outline variant so cancel uses primary style

## Testing
- `npm run lint` *(fails: expo not found)*

------
https://chatgpt.com/codex/tasks/task_e_684eec8988d88320a82735cfd4eed27f