### PR TITLE
Add theme context and provider

### DIFF
--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -4,6 +4,7 @@ import { Stack } from 'expo-router';
 import { StatusBar } from 'expo-status-bar';
 import { SplashScreen } from 'expo-router';
 import { useFrameworkReady } from '@/hooks/useFrameworkReady';
+import { ThemeProvider } from '@/theme/ThemeContext';
 
 // Prevent splash screen from auto-hiding
 SplashScreen.preventAutoHideAsync();
@@ -28,12 +29,12 @@ export default function RootLayout() {
   }
 
   return (
-    <>
+    <ThemeProvider>
       <Stack screenOptions={{ headerShown: false }}>
         <Stack.Screen name="(tabs)" options={{ headerShown: false }} />
         <Stack.Screen name="+not-found" />
       </Stack>
       <StatusBar style="dark" />
-    </>
+    </ThemeProvider>
   );
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
         "@expo-google-fonts/roboto": "^0.2.3",
         "@expo/vector-icons": "^14.1.0",
         "@lucide/lab": "^0.1.2",
+        "@react-native-async-storage/async-storage": "^1.21.0",
         "@react-navigation/bottom-tabs": "^7.2.0",
         "@react-navigation/native": "^7.0.14",
         "expo": "^53.0.0",
@@ -2313,6 +2314,18 @@
         "@types/react": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@react-native-async-storage/async-storage": {
+      "version": "1.24.0",
+      "resolved": "https://registry.npmjs.org/@react-native-async-storage/async-storage/-/async-storage-1.24.0.tgz",
+      "integrity": "sha512-W4/vbwUOYOjco0x3toB8QCr7EjIP6nE9G7o8PMguvvjYT5Awg09lyV4enACRx4s++PPulBiBSjL0KTFx2u0Z/g==",
+      "license": "MIT",
+      "dependencies": {
+        "merge-options": "^3.0.4"
+      },
+      "peerDependencies": {
+        "react-native": "^0.0.0-0 || >=0.60 <1.0"
       }
     },
     "node_modules/@react-native/assets-registry": {
@@ -4944,6 +4957,15 @@
         "node": ">=0.12.0"
       }
     },
+    "node_modules/is-plain-obj": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-2.1.0.tgz",
+      "integrity": "sha512-YWnfyRwxL/+SsrWYfOpUtz5b3YD+nyfkHvjbcanzk8zgyO4ASD67uVMRt8k5bM4lLMDnXfriRhOpemw+NfT1eA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/is-wsl": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-2.2.0.tgz",
@@ -5652,6 +5674,18 @@
       "version": "5.2.1",
       "resolved": "https://registry.npmjs.org/memoize-one/-/memoize-one-5.2.1.tgz",
       "integrity": "sha512-zYiwtZUcYyXKo/np96AGZAckk+FWWsUdJ3cHGGmld7+AhvcWmQyGCYUh1hc4Q/pkOhb65dQR/pqCyK0cOaHz4Q=="
+    },
+    "node_modules/merge-options": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/merge-options/-/merge-options-3.0.4.tgz",
+      "integrity": "sha512-2Sug1+knBjkaMsMgf1ctR1Ujx+Ayku4EdJN4Z+C2+JzoeF7A3OZ9KM2GY0CpQS51NR61LTurMJrRKPhSs3ZRTQ==",
+      "license": "MIT",
+      "dependencies": {
+        "is-plain-obj": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
     },
     "node_modules/merge-stream": {
       "version": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -44,7 +44,8 @@
     "react-native-svg": "15.11.2",
     "react-native-url-polyfill": "^2.0.0",
     "react-native-web": "^0.20.0",
-    "react-native-webview": "13.13.5"
+    "react-native-webview": "13.13.5",
+    "@react-native-async-storage/async-storage": "^1.21.0"
   },
   "devDependencies": {
     "@babel/core": "^7.25.2",

--- a/theme/ThemeContext.tsx
+++ b/theme/ThemeContext.tsx
@@ -1,0 +1,69 @@
+import React, { createContext, useContext, useEffect, useState } from 'react';
+import { Appearance } from 'react-native';
+import AsyncStorage from '@react-native-async-storage/async-storage';
+
+export const lightTheme = {
+  mode: 'light' as const,
+  background: '#ffffff',
+  text: '#1f2937',
+  card: '#f8fafc',
+  border: '#e2e8f0',
+};
+
+export const darkTheme = {
+  mode: 'dark' as const,
+  background: '#0f172a',
+  text: '#f8fafc',
+  card: '#1e293b',
+  border: '#334155',
+};
+
+type Theme = typeof lightTheme;
+
+interface ThemeContextValue {
+  theme: Theme;
+  toggleTheme: () => void;
+}
+
+const ThemeContext = createContext<ThemeContextValue>({
+  theme: lightTheme,
+  toggleTheme: () => {},
+});
+
+const STORAGE_KEY = 'app-theme';
+
+export function ThemeProvider({ children }: { children: React.ReactNode }) {
+  const systemScheme = Appearance.getColorScheme();
+  const [theme, setTheme] = useState<Theme>(
+    systemScheme === 'dark' ? darkTheme : lightTheme
+  );
+
+  useEffect(() => {
+    (async () => {
+      const stored = await AsyncStorage.getItem(STORAGE_KEY);
+      if (stored === 'dark') {
+        setTheme(darkTheme);
+      } else if (stored === 'light') {
+        setTheme(lightTheme);
+      }
+    })();
+  }, []);
+
+  const toggleTheme = async () => {
+    const newTheme = theme.mode === 'light' ? darkTheme : lightTheme;
+    setTheme(newTheme);
+    await AsyncStorage.setItem(STORAGE_KEY, newTheme.mode);
+  };
+
+  return (
+    <ThemeContext.Provider value={{ theme, toggleTheme }}>
+      {children}
+    </ThemeContext.Provider>
+  );
+}
+
+export function useTheme() {
+  return useContext(ThemeContext);
+}
+
+export { ThemeContext };


### PR DESCRIPTION
## Summary
- add a ThemeContext with light and dark palettes
- persist selected theme using AsyncStorage
- wrap RootLayout in ThemeProvider
- add async-storage dependency

## Testing
- `npm run lint` *(fails: fetch failed while configuring eslint)*

------
https://chatgpt.com/codex/tasks/task_e_684eec0516188320af3ea7c941da1235