### PR TITLE
Add dark mode toggle

### DIFF
--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -4,6 +4,7 @@ import { Stack } from 'expo-router';
 import { StatusBar } from 'expo-status-bar';
 import { SplashScreen } from 'expo-router';
 import { useFrameworkReady } from '@/hooks/useFrameworkReady';
+import { ThemeProvider, useTheme } from '@/contexts/ThemeContext';
 
 // Prevent splash screen from auto-hiding
 SplashScreen.preventAutoHideAsync();
@@ -28,12 +29,22 @@ export default function RootLayout() {
   }
 
   return (
+    <ThemeProvider>
+      <RootContent />
+    </ThemeProvider>
+  );
+}
+
+function RootContent() {
+  const { theme } = useTheme();
+
+  return (
     <>
       <Stack screenOptions={{ headerShown: false }}>
         <Stack.Screen name="(tabs)" options={{ headerShown: false }} />
         <Stack.Screen name="+not-found" />
       </Stack>
-      <StatusBar style="dark" />
+      <StatusBar style={theme === 'dark' ? 'light' : 'dark'} />
     </>
   );
 }

--- a/components/SettingsSection.tsx
+++ b/components/SettingsSection.tsx
@@ -1,12 +1,16 @@
 import React from 'react';
-import { View, Text, StyleSheet, TouchableOpacity, Linking, Alert } from 'react-native';
-import { ExternalLink, Shield, FileText, Info, RotateCcw, Globe } from 'lucide-react-native';
+import { View, Text, StyleSheet, TouchableOpacity, Linking, Alert, Switch } from 'react-native';
+import { ExternalLink, Shield, FileText, Info, RotateCcw, Globe, Moon } from 'lucide-react-native';
+import { useTheme } from '@/contexts/ThemeContext';
 
 interface SettingsSectionProps {
   onResetProfile: () => void;
 }
 
 export default function SettingsSection({ onResetProfile }: SettingsSectionProps) {
+  const { theme, toggleTheme } = useTheme();
+
+  const isDarkMode = theme === 'dark';
   const openLink = (url: string, title: string) => {
     Alert.alert(
       title,
@@ -65,7 +69,7 @@ export default function SettingsSection({ onResetProfile }: SettingsSectionProps
           return (
             <TouchableOpacity
               key={index}
-              style={[styles.settingItem, index < settingsItems.length - 1 && styles.borderBottom]}
+              style={[styles.settingItem, index < settingsItems.length && styles.borderBottom]}
               onPress={item.onPress}
             >
               <View style={styles.settingIcon}>
@@ -79,6 +83,25 @@ export default function SettingsSection({ onResetProfile }: SettingsSectionProps
             </TouchableOpacity>
           );
         })}
+      </View>
+
+      <View style={styles.card}>
+        <TouchableOpacity
+          style={styles.settingItem}
+          onPress={toggleTheme}
+        >
+          <View style={styles.settingIcon}>
+            <Moon size={20} color="#6b7280" />
+          </View>
+          <View style={styles.settingContent}>
+            <Text style={styles.settingTitle}>Mode sombre</Text>
+          </View>
+          <Switch
+            value={isDarkMode}
+            onValueChange={toggleTheme}
+            style={styles.settingSwitch}
+          />
+        </TouchableOpacity>
       </View>
 
       <View style={styles.card}>
@@ -160,6 +183,9 @@ const styles = StyleSheet.create({
   },
   settingContent: {
     flex: 1,
+  },
+  settingSwitch: {
+    marginLeft: 'auto',
   },
   settingTitle: {
     fontSize: 16,

--- a/contexts/ThemeContext.tsx
+++ b/contexts/ThemeContext.tsx
@@ -1,0 +1,34 @@
+import React, { createContext, useContext, useState, ReactNode } from 'react';
+import { Appearance } from 'react-native';
+
+type Theme = 'light' | 'dark';
+
+interface ThemeContextValue {
+  theme: Theme;
+  toggleTheme: () => void;
+}
+
+const ThemeContext = createContext<ThemeContextValue | undefined>(undefined);
+
+export function ThemeProvider({ children }: { children: ReactNode }) {
+  const colorScheme = Appearance.getColorScheme();
+  const [theme, setTheme] = useState<Theme>(colorScheme === 'dark' ? 'dark' : 'light');
+
+  const toggleTheme = () => {
+    setTheme(prev => (prev === 'light' ? 'dark' : 'light'));
+  };
+
+  return (
+    <ThemeContext.Provider value={{ theme, toggleTheme }}>
+      {children}
+    </ThemeContext.Provider>
+  );
+}
+
+export function useTheme() {
+  const context = useContext(ThemeContext);
+  if (!context) {
+    throw new Error('useTheme must be used within a ThemeProvider');
+  }
+  return context;
+}


### PR DESCRIPTION
## Summary
- create a simple ThemeContext to manage light/dark mode
- wrap app layout with ThemeProvider and use theme to set `StatusBar`
- add a dark mode switch to settings

## Testing
- `npm run lint` *(fails: fetch failed)*

------
https://chatgpt.com/codex/tasks/task_e_684eec071e7483209fd9dc00a2cea600