### PR TITLE
Implement theme context and use in styles

### DIFF
--- a/app/(tabs)/_layout.tsx
+++ b/app/(tabs)/_layout.tsx
@@ -1,15 +1,31 @@
 import { Tabs } from 'expo-router';
 import { Chrome as Home, FileText, History, Settings } from 'lucide-react-native';
 import { View, StyleSheet, Platform } from 'react-native';
+import { useTheme } from '@/contexts/ThemeContext';
 
 export default function TabLayout() {
+  const { colors } = useTheme();
+  const styles = useMemo(
+    () =>
+      StyleSheet.create({
+        tabBar: {
+          borderTopWidth: 1,
+          paddingTop: 8,
+          paddingBottom: Platform.OS === 'ios' ? 34 : 8,
+          height: Platform.OS === 'ios' ? 88 : 64,
+        },
+        tabBarLabel: { fontFamily: 'Roboto-Medium', fontSize: 12, marginTop: 4 },
+        tabBarItem: { paddingTop: 4 },
+      }),
+    [colors]
+  );
   return (
     <Tabs
       screenOptions={{
         headerShown: false,
-        tabBarStyle: styles.tabBar,
-        tabBarActiveTintColor: '#1e40af',
-        tabBarInactiveTintColor: '#64748b',
+        tabBarStyle: [styles.tabBar, { backgroundColor: colors.card, borderTopColor: colors.border }],
+        tabBarActiveTintColor: colors.primary,
+        tabBarInactiveTintColor: colors.textSecondary,
         tabBarLabelStyle: styles.tabBarLabel,
         tabBarItemStyle: styles.tabBarItem,
       }}>
@@ -52,22 +68,3 @@ export default function TabLayout() {
     </Tabs>
   );
 }
-
-const styles = StyleSheet.create({
-  tabBar: {
-    backgroundColor: '#ffffff',
-    borderTopWidth: 1,
-    borderTopColor: '#e2e8f0',
-    paddingTop: 8,
-    paddingBottom: Platform.OS === 'ios' ? 34 : 8,
-    height: Platform.OS === 'ios' ? 88 : 64,
-  },
-  tabBarLabel: {
-    fontFamily: 'Roboto-Medium',
-    fontSize: 12,
-    marginTop: 4,
-  },
-  tabBarItem: {
-    paddingTop: 4,
-  },
-});

--- a/app/(tabs)/create.tsx
+++ b/app/(tabs)/create.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect, useMemo } from 'react';
 import { View, ScrollView, StyleSheet, Alert } from 'react-native';
 import Header from '@/components/Header';
 import LetterTypeSelector from '@/components/LetterTypeSelector';
@@ -8,6 +8,7 @@ import ActionButton from '@/components/ActionButton';
 import LoadingOverlay from '@/components/LoadingOverlay';
 import { LetterType, Recipient, UserProfile } from '@/types/letter';
 import { letterService } from '@/services/letterService';
+import { useTheme } from '@/contexts/ThemeContext';
 import { FileText, Send } from 'lucide-react-native';
 import { router } from 'expo-router';
 
@@ -21,6 +22,18 @@ export default function CreateScreen() {
   const [additionalInfo, setAdditionalInfo] = useState<Record<string, any>>({});
   const [userProfile, setUserProfile] = useState<UserProfile | null>(null);
   const [isGenerating, setIsGenerating] = useState(false);
+  const { colors } = useTheme();
+
+  const styles = useMemo(
+    () =>
+      StyleSheet.create({
+        container: { flex: 1, backgroundColor: colors.background },
+        content: { flex: 1, paddingHorizontal: 20 },
+        section: { marginTop: 24 },
+        buttonGroup: { gap: 12, marginBottom: 32 },
+      }),
+    [colors]
+  );
 
   useEffect(() => {
     loadUserProfile();
@@ -143,21 +156,3 @@ export default function CreateScreen() {
     </View>
   );
 }
-
-const styles = StyleSheet.create({
-  container: {
-    flex: 1,
-    backgroundColor: '#f8fafc',
-  },
-  content: {
-    flex: 1,
-    paddingHorizontal: 20,
-  },
-  section: {
-    marginTop: 24,
-  },
-  buttonGroup: {
-    gap: 12,
-    marginBottom: 32,
-  },
-});

--- a/app/(tabs)/history.tsx
+++ b/app/(tabs)/history.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useState, useMemo } from 'react';
 import { View, ScrollView, StyleSheet, RefreshControl, Alert } from 'react-native';
 import Header from '@/components/Header';
 import LetterCard from '@/components/LetterCard';
@@ -6,11 +6,23 @@ import EmptyState from '@/components/EmptyState';
 import { Letter } from '@/types/letter';
 import { letterService } from '@/services/letterService';
 import { FileText } from 'lucide-react-native';
+import { useTheme } from '@/contexts/ThemeContext';
 
 export default function HistoryScreen() {
   const [letters, setLetters] = useState<Letter[]>([]);
   const [refreshing, setRefreshing] = useState(false);
   const [loading, setLoading] = useState(true);
+  const { colors } = useTheme();
+
+  const styles = useMemo(
+    () =>
+      StyleSheet.create({
+        container: { flex: 1, backgroundColor: colors.background },
+        content: { flex: 1, paddingHorizontal: 20 },
+        lettersList: { paddingTop: 20, paddingBottom: 32, gap: 16 },
+      }),
+    [colors]
+  );
 
   const loadLetters = async () => {
     try {
@@ -102,19 +114,3 @@ export default function HistoryScreen() {
     </View>
   );
 }
-
-const styles = StyleSheet.create({
-  container: {
-    flex: 1,
-    backgroundColor: '#f8fafc',
-  },
-  content: {
-    flex: 1,
-    paddingHorizontal: 20,
-  },
-  lettersList: {
-    paddingTop: 20,
-    paddingBottom: 32,
-    gap: 16,
-  },
-});

--- a/app/(tabs)/index.tsx
+++ b/app/(tabs)/index.tsx
@@ -1,9 +1,10 @@
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useState, useMemo } from 'react';
 import { View, ScrollView, StyleSheet, RefreshControl, Text, Image } from 'react-native';
 import { FileText, TrendingUp, Calendar, Users, User } from 'lucide-react-native';
 import Header from '@/components/Header';
 import StatsCard from '@/components/StatsCard';
 import ActionButton from '@/components/ActionButton';
+import { useTheme } from '@/contexts/ThemeContext';
 import { letterService } from '@/services/letterService';
 import { Statistics, UserProfile } from '@/types/letter';
 import { router } from 'expo-router';
@@ -12,6 +13,63 @@ export default function HomeScreen() {
   const [stats, setStats] = useState<Statistics | null>(null);
   const [userProfile, setUserProfile] = useState<UserProfile | null>(null);
   const [refreshing, setRefreshing] = useState(false);
+  const { colors } = useTheme();
+
+  const styles = useMemo(
+    () =>
+      StyleSheet.create({
+        container: { flex: 1, backgroundColor: colors.background },
+        content: { flex: 1, paddingHorizontal: 20 },
+        welcomeSection: { marginTop: 20, marginBottom: 8 },
+        welcomeContent: {
+          backgroundColor: colors.card,
+          borderRadius: 16,
+          padding: 20,
+          flexDirection: 'row',
+          alignItems: 'center',
+          justifyContent: 'space-between',
+          shadowColor: colors.shadow,
+          shadowOffset: { width: 0, height: 2 },
+          shadowOpacity: 0.1,
+          shadowRadius: 8,
+          elevation: 4,
+        },
+        welcomeText: { flex: 1 },
+        greeting: {
+          fontSize: 22,
+          fontFamily: 'Roboto-Bold',
+          color: colors.textPrimary,
+          marginBottom: 4,
+        },
+        welcomeSubtext: {
+          fontSize: 16,
+          fontFamily: 'Roboto-Regular',
+          color: colors.textSecondary,
+          lineHeight: 22,
+        },
+        profileImageContainer: { marginLeft: 16 },
+        profileImage: {
+          width: 60,
+          height: 60,
+          borderRadius: 30,
+          borderWidth: 3,
+          borderColor: colors.border,
+        },
+        profilePlaceholder: {
+          width: 60,
+          height: 60,
+          borderRadius: 30,
+          backgroundColor: colors.surfaceMuted,
+          alignItems: 'center',
+          justifyContent: 'center',
+          borderWidth: 3,
+          borderColor: colors.border,
+        },
+        section: { marginTop: 24 },
+        statsGrid: { flexDirection: 'row', marginBottom: 12 },
+      }),
+    [colors]
+  );
 
   const loadData = async () => {
     try {
@@ -81,7 +139,7 @@ export default function HomeScreen() {
                 <Image source={{ uri: userProfile.photoUri }} style={styles.profileImage} />
               ) : (
                 <View style={styles.profilePlaceholder}>
-                  <User size={24} color="#6b7280" />
+                  <User size={24} color={colors.textSecondary} />
                 </View>
               )}
             </View>
@@ -143,76 +201,3 @@ export default function HomeScreen() {
     </View>
   );
 }
-
-const styles = StyleSheet.create({
-  container: {
-    flex: 1,
-    backgroundColor: '#f8fafc',
-  },
-  content: {
-    flex: 1,
-    paddingHorizontal: 20,
-  },
-  welcomeSection: {
-    marginTop: 20,
-    marginBottom: 8,
-  },
-  welcomeContent: {
-    backgroundColor: '#ffffff',
-    borderRadius: 16,
-    padding: 20,
-    flexDirection: 'row',
-    alignItems: 'center',
-    justifyContent: 'space-between',
-    shadowColor: '#000',
-    shadowOffset: {
-      width: 0,
-      height: 2,
-    },
-    shadowOpacity: 0.1,
-    shadowRadius: 8,
-    elevation: 4,
-  },
-  welcomeText: {
-    flex: 1,
-  },
-  greeting: {
-    fontSize: 22,
-    fontFamily: 'Roboto-Bold',
-    color: '#1f2937',
-    marginBottom: 4,
-  },
-  welcomeSubtext: {
-    fontSize: 16,
-    fontFamily: 'Roboto-Regular',
-    color: '#6b7280',
-    lineHeight: 22,
-  },
-  profileImageContainer: {
-    marginLeft: 16,
-  },
-  profileImage: {
-    width: 60,
-    height: 60,
-    borderRadius: 30,
-    borderWidth: 3,
-    borderColor: '#e5e7eb',
-  },
-  profilePlaceholder: {
-    width: 60,
-    height: 60,
-    borderRadius: 30,
-    backgroundColor: '#f3f4f6',
-    alignItems: 'center',
-    justifyContent: 'center',
-    borderWidth: 3,
-    borderColor: '#e5e7eb',
-  },
-  section: {
-    marginTop: 24,
-  },
-  statsGrid: {
-    flexDirection: 'row',
-    marginBottom: 12,
-  },
-});

--- a/app/(tabs)/settings.tsx
+++ b/app/(tabs)/settings.tsx
@@ -1,14 +1,26 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect, useMemo } from 'react';
 import { View, ScrollView, StyleSheet, Alert } from 'react-native';
 import Header from '@/components/Header';
 import ProfileSection from '@/components/ProfileSection';
 import SettingsSection from '@/components/SettingsSection';
+import { useTheme } from '@/contexts/ThemeContext';
 import { UserProfile } from '@/types/letter';
 import { letterService } from '@/services/letterService';
 
 export default function SettingsScreen() {
   const [userProfile, setUserProfile] = useState<UserProfile | null>(null);
   const [loading, setLoading] = useState(true);
+  const { colors } = useTheme();
+
+  const styles = useMemo(
+    () =>
+      StyleSheet.create({
+        container: { flex: 1, backgroundColor: colors.background },
+        content: { flex: 1, paddingHorizontal: 20 },
+        section: { marginTop: 24 },
+      }),
+    [colors]
+  );
 
   const loadProfile = async () => {
     try {
@@ -81,17 +93,3 @@ export default function SettingsScreen() {
     </View>
   );
 }
-
-const styles = StyleSheet.create({
-  container: {
-    flex: 1,
-    backgroundColor: '#f8fafc',
-  },
-  content: {
-    flex: 1,
-    paddingHorizontal: 20,
-  },
-  section: {
-    marginTop: 24,
-  },
-});

--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -4,6 +4,7 @@ import { Stack } from 'expo-router';
 import { StatusBar } from 'expo-status-bar';
 import { SplashScreen } from 'expo-router';
 import { useFrameworkReady } from '@/hooks/useFrameworkReady';
+import { ThemeProvider } from '@/contexts/ThemeContext';
 
 // Prevent splash screen from auto-hiding
 SplashScreen.preventAutoHideAsync();
@@ -28,12 +29,12 @@ export default function RootLayout() {
   }
 
   return (
-    <>
+    <ThemeProvider>
       <Stack screenOptions={{ headerShown: false }}>
         <Stack.Screen name="(tabs)" options={{ headerShown: false }} />
         <Stack.Screen name="+not-found" />
       </Stack>
       <StatusBar style="dark" />
-    </>
+    </ThemeProvider>
   );
 }

--- a/app/letter-preview.tsx
+++ b/app/letter-preview.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useMemo } from 'react';
 import {
   View,
   ScrollView,
@@ -22,9 +22,48 @@ import {
 import * as Print from 'expo-print';
 import * as FileSystem from 'expo-file-system';
 import * as Sharing from 'expo-sharing';
+import { useTheme } from '@/contexts/ThemeContext';
 
 export default function LetterPreviewScreen() {
   const { content } = useLocalSearchParams<{ content?: string }>();
+  const { colors } = useTheme();
+
+  const styles = useMemo(
+    () =>
+      StyleSheet.create({
+        container: { flex: 1, backgroundColor: colors.background },
+        content: {
+          flex: 1,
+          paddingHorizontal: 20,
+          paddingVertical: 20,
+        },
+        letterText: {
+          fontSize: 16,
+          fontFamily: 'Roboto-Regular',
+          color: colors.textPrimary,
+          lineHeight: 24,
+        },
+        toolbar: {
+          flexDirection: 'row',
+          justifyContent: 'space-between',
+          paddingHorizontal: 20,
+          paddingVertical: 12,
+          borderTopWidth: 1,
+          borderColor: colors.border,
+          backgroundColor: colors.card,
+          gap: 8,
+        },
+        toolbarButton: {
+          width: 40,
+          height: 40,
+          borderRadius: 20,
+          backgroundColor: colors.background,
+          alignItems: 'center',
+          justifyContent: 'center',
+        },
+      }),
+    [colors]
+  );
 
   const handleShare = async () => {
     if (!content) return;
@@ -75,57 +114,22 @@ export default function LetterPreviewScreen() {
           style={styles.toolbarButton}
           onPress={() => router.back()}
         >
-          <ArrowLeft size={18} color="#6b7280" />
+          <ArrowLeft size={18} color={colors.textSecondary} />
         </TouchableOpacity>
 
         <TouchableOpacity style={styles.toolbarButton} onPress={handleShare}>
-          <ShareIcon size={18} color="#6b7280" />
+          <ShareIcon size={18} color={colors.textSecondary} />
         </TouchableOpacity>
 
         <TouchableOpacity style={styles.toolbarButton} onPress={handleDownload}>
-          <FileDown size={18} color="#6b7280" />
+          <FileDown size={18} color={colors.textSecondary} />
         </TouchableOpacity>
 
         <TouchableOpacity style={styles.toolbarButton} onPress={handleEmail}>
-          <Mail size={18} color="#6b7280" />
+          <Mail size={18} color={colors.textSecondary} />
         </TouchableOpacity>
       </View>
     </View>
   );
 }
 
-const styles = StyleSheet.create({
-  container: {
-    flex: 1,
-    backgroundColor: '#f8fafc',
-  },
-  content: {
-    flex: 1,
-    paddingHorizontal: 20,
-    paddingVertical: 20,
-  },
-  letterText: {
-    fontSize: 16,
-    fontFamily: 'Roboto-Regular',
-    color: '#1f2937',
-    lineHeight: 24,
-  },
-  toolbar: {
-    flexDirection: 'row',
-    justifyContent: 'space-between',
-    paddingHorizontal: 20,
-    paddingVertical: 12,
-    borderTopWidth: 1,
-    borderColor: '#e5e7eb',
-    backgroundColor: '#ffffff',
-    gap: 8,
-  },
-  toolbarButton: {
-    width: 40,
-    height: 40,
-    borderRadius: 20,
-    backgroundColor: '#f8fafc',
-    alignItems: 'center',
-    justifyContent: 'center',
-  },
-});

--- a/components/ActionButton.tsx
+++ b/components/ActionButton.tsx
@@ -1,6 +1,7 @@
-import React from 'react';
+import React, { useMemo } from 'react';
 import { TouchableOpacity, Text, StyleSheet, View } from 'react-native';
 import type { LucideIcon } from 'lucide-react-native';
+import { useTheme } from '@/contexts/ThemeContext';
 
 interface ActionButtonProps {
   title: string;
@@ -19,12 +20,57 @@ export default function ActionButton({
   size = 'medium',
   disabled = false,
 }: ActionButtonProps) {
-  const buttonStyles = [
-    styles.button,
-    styles[variant],
-    styles[size],
-    disabled && styles.disabled,
-  ];
+  const { colors } = useTheme();
+
+  const styles = useMemo(
+    () =>
+      StyleSheet.create({
+        button: {
+          borderRadius: 12,
+          alignItems: 'center',
+          justifyContent: 'center',
+          shadowColor: colors.shadow,
+          shadowOffset: { width: 0, height: 2 },
+          shadowOpacity: 0.1,
+          shadowRadius: 4,
+          elevation: 2,
+        },
+        content: {
+          flexDirection: 'row',
+          alignItems: 'center',
+          justifyContent: 'center',
+        },
+        icon: { marginRight: 8 },
+        text: {
+          fontFamily: 'Roboto-Medium',
+          textAlign: 'center',
+        },
+        primary: { backgroundColor: colors.primary },
+        secondary: { backgroundColor: colors.success },
+        outline: {
+          backgroundColor: 'transparent',
+          borderWidth: 2,
+          borderColor: colors.primary,
+        },
+        small: { paddingVertical: 8, paddingHorizontal: 16 },
+        medium: { paddingVertical: 12, paddingHorizontal: 24 },
+        large: { paddingVertical: 16, paddingHorizontal: 32 },
+        primaryText: { color: colors.card },
+        secondaryText: { color: colors.card },
+        outlineText: { color: colors.primary },
+        smallText: { fontSize: 14 },
+        mediumText: { fontSize: 16 },
+        largeText: { fontSize: 18 },
+        disabled: {
+          backgroundColor: colors.surfaceLight,
+          borderColor: colors.border,
+        },
+        disabledText: { color: colors.textMuted },
+      }),
+    [colors]
+  );
+
+  const buttonStyles = [styles.button, styles[variant], styles[size], disabled && styles.disabled];
 
   const textStyles = [
     styles.text,
@@ -46,12 +92,10 @@ export default function ActionButton({
             size={size === 'small' ? 16 : size === 'large' ? 24 : 20}
             color={
               disabled
-                ? '#9ca3af'
-                : variant === 'primary'
-                ? '#ffffff'
-                : variant === 'secondary'
-                ? '#ffffff'
-                : '#1e40af'
+                ? colors.textMuted
+                : variant === 'primary' || variant === 'secondary'
+                ? colors.card
+                : colors.primary
             }
             style={styles.icon}
           />
@@ -61,84 +105,3 @@ export default function ActionButton({
     </TouchableOpacity>
   );
 }
-
-const styles = StyleSheet.create({
-  button: {
-    borderRadius: 12,
-    alignItems: 'center',
-    justifyContent: 'center',
-    shadowColor: '#000',
-    shadowOffset: {
-      width: 0,
-      height: 2,
-    },
-    shadowOpacity: 0.1,
-    shadowRadius: 4,
-    elevation: 2,
-  },
-  content: {
-    flexDirection: 'row',
-    alignItems: 'center',
-    justifyContent: 'center',
-  },
-  icon: {
-    marginRight: 8,
-  },
-  text: {
-    fontFamily: 'Roboto-Medium',
-    textAlign: 'center',
-  },
-  // Variants
-  primary: {
-    backgroundColor: '#1e40af',
-  },
-  secondary: {
-    backgroundColor: '#10b981',
-  },
-  outline: {
-    backgroundColor: 'transparent',
-    borderWidth: 2,
-    borderColor: '#1e40af',
-  },
-  // Sizes
-  small: {
-    paddingVertical: 8,
-    paddingHorizontal: 16,
-  },
-  medium: {
-    paddingVertical: 12,
-    paddingHorizontal: 24,
-  },
-  large: {
-    paddingVertical: 16,
-    paddingHorizontal: 32,
-  },
-  // Text variants
-  primaryText: {
-    color: '#ffffff',
-  },
-  secondaryText: {
-    color: '#ffffff',
-  },
-  outlineText: {
-    color: '#1e40af',
-  },
-  // Text sizes
-  smallText: {
-    fontSize: 14,
-  },
-  mediumText: {
-    fontSize: 16,
-  },
-  largeText: {
-    fontSize: 18,
-  },
-  // Disabled states
-  disabled: {
-    backgroundColor: '#f1f5f9',
-    borderColor: '#e2e8f0',
-  },
-  disabledText: {
-    color: '#9ca3af',
-  },
-});

--- a/components/EmptyState.tsx
+++ b/components/EmptyState.tsx
@@ -1,7 +1,8 @@
-import React from 'react';
+import React, { useMemo } from 'react';
 import { View, Text, StyleSheet } from 'react-native';
 import type { LucideIcon } from 'lucide-react-native';
 import ActionButton from '@/components/ActionButton';
+import { useTheme } from '@/contexts/ThemeContext';
 
 interface EmptyStateProps {
   icon: LucideIcon;
@@ -11,17 +12,50 @@ interface EmptyStateProps {
   onAction?: () => void;
 }
 
-export default function EmptyState({ 
+export default function EmptyState({
   icon: Icon, 
   title, 
   description, 
   actionTitle, 
   onAction 
 }: EmptyStateProps) {
+  const { colors } = useTheme();
+
+  const styles = useMemo(
+    () =>
+      StyleSheet.create({
+        container: {
+          flex: 1,
+          alignItems: 'center',
+          justifyContent: 'center',
+          paddingHorizontal: 40,
+          paddingVertical: 60,
+        },
+        iconContainer: { marginBottom: 24 },
+        title: {
+          fontSize: 20,
+          fontFamily: 'Roboto-Bold',
+          color: colors.textPrimary,
+          textAlign: 'center',
+          marginBottom: 12,
+        },
+        description: {
+          fontSize: 16,
+          fontFamily: 'Roboto-Regular',
+          color: colors.textSecondary,
+          textAlign: 'center',
+          lineHeight: 24,
+          marginBottom: 32,
+        },
+        action: { width: '100%' },
+      }),
+    [colors]
+  );
+
   return (
     <View style={styles.container}>
       <View style={styles.iconContainer}>
-        <Icon size={64} color="#d1d5db" />
+        <Icon size={64} color={colors.borderAlt} />
       </View>
       
       <Text style={styles.title}>{title}</Text>
@@ -40,34 +74,3 @@ export default function EmptyState({
     </View>
   );
 }
-
-const styles = StyleSheet.create({
-  container: {
-    flex: 1,
-    alignItems: 'center',
-    justifyContent: 'center',
-    paddingHorizontal: 40,
-    paddingVertical: 60,
-  },
-  iconContainer: {
-    marginBottom: 24,
-  },
-  title: {
-    fontSize: 20,
-    fontFamily: 'Roboto-Bold',
-    color: '#1f2937',
-    textAlign: 'center',
-    marginBottom: 12,
-  },
-  description: {
-    fontSize: 16,
-    fontFamily: 'Roboto-Regular',
-    color: '#6b7280',
-    textAlign: 'center',
-    lineHeight: 24,
-    marginBottom: 32,
-  },
-  action: {
-    width: '100%',
-  },
-});

--- a/components/FormDatePicker.tsx
+++ b/components/FormDatePicker.tsx
@@ -1,6 +1,7 @@
-import React, { useState } from 'react';
+import React, { useState, useMemo } from 'react';
 import { View, Text, TouchableOpacity, StyleSheet, Platform } from 'react-native';
 import { Calendar } from 'lucide-react-native';
+import { useTheme } from '@/contexts/ThemeContext';
 
 interface FormDatePickerProps {
   label: string;
@@ -24,6 +25,40 @@ export default function FormDatePicker({ label, value, onDateChange, required }:
     setIsVisible(false);
   };
 
+  const { colors } = useTheme();
+
+  const styles = useMemo(
+    () =>
+      StyleSheet.create({
+        container: { marginBottom: 4 },
+        label: {
+          fontSize: 14,
+          fontFamily: 'Roboto-Medium',
+          color: colors.label ?? colors.textSecondary,
+          marginBottom: 8,
+        },
+        required: { color: colors.danger },
+        dateSelector: {
+          backgroundColor: colors.card,
+          borderWidth: 1,
+          borderColor: colors.borderAlt,
+          borderRadius: 12,
+          paddingHorizontal: 16,
+          paddingVertical: 12,
+          flexDirection: 'row',
+          alignItems: 'center',
+          justifyContent: 'space-between',
+        },
+        dateText: {
+          fontSize: 16,
+          fontFamily: 'Roboto-Regular',
+          color: colors.textPrimary,
+        },
+        placeholder: { color: colors.textMuted },
+      }),
+    [colors]
+  );
+
   return (
     <View style={styles.container}>
       <Text style={styles.label}>
@@ -35,42 +70,8 @@ export default function FormDatePicker({ label, value, onDateChange, required }:
         <Text style={[styles.dateText, !value && styles.placeholder]}>
           {value || 'Sélectionner une date...'}
         </Text>
-        <Calendar size={20} color="#6b7280" />
+        <Calendar size={20} color={colors.textSecondary} />
       </TouchableOpacity>
     </View>
   );
 }
-
-const styles = StyleSheet.create({
-  container: {
-    marginBottom: 4,
-  },
-  label: {
-    fontSize: 14,
-    fontFamily: 'Roboto-Medium',
-    color: '#374151',
-    marginBottom: 8,
-  },
-  required: {
-    color: '#ef4444',
-  },
-  dateSelector: {
-    backgroundColor: '#ffffff',
-    borderWidth: 1,
-    borderColor: '#d1d5db',
-    borderRadius: 12,
-    paddingHorizontal: 16,
-    paddingVertical: 12,
-    flexDirection: 'row',
-    alignItems: 'center',
-    justifyContent: 'space-between',
-  },
-  dateText: {
-    fontSize: 16,
-    fontFamily: 'Roboto-Regular',
-    color: '#1f2937',
-  },
-  placeholder: {
-    color: '#9ca3af',
-  },
-});

--- a/components/FormInput.tsx
+++ b/components/FormInput.tsx
@@ -1,5 +1,6 @@
-import React from 'react';
+import React, { useMemo } from 'react';
 import { View, Text, TextInput, StyleSheet, ViewStyle } from 'react-native';
+import { useTheme } from '@/contexts/ThemeContext';
 
 interface FormInputProps {
   label: string;
@@ -28,6 +29,38 @@ export default function FormInput({
   maxLength,
   style,
 }: FormInputProps) {
+  const { colors } = useTheme();
+
+  const styles = useMemo(
+    () =>
+      StyleSheet.create({
+        container: { marginBottom: 4 },
+        label: {
+          fontSize: 14,
+          fontFamily: 'Roboto-Medium',
+          color: colors.label ?? colors.textSecondary,
+          marginBottom: 8,
+        },
+        required: { color: colors.danger },
+        input: {
+          backgroundColor: colors.card,
+          borderWidth: 1,
+          borderColor: colors.borderAlt,
+          borderRadius: 12,
+          paddingHorizontal: 16,
+          paddingVertical: 12,
+          fontSize: 16,
+          fontFamily: 'Roboto-Regular',
+          color: colors.textPrimary,
+        },
+        multilineInput: {
+          paddingTop: 12,
+          textAlignVertical: 'top',
+        },
+      }),
+    [colors]
+  );
+
   return (
     <View style={[styles.container, style]}>
       <Text style={styles.label}>
@@ -43,7 +76,7 @@ export default function FormInput({
         value={value}
         onChangeText={onChangeText}
         placeholder={placeholder}
-        placeholderTextColor="#9ca3af"
+        placeholderTextColor={colors.textMuted}
         multiline={multiline}
         numberOfLines={multiline ? numberOfLines : 1}
         keyboardType={keyboardType}
@@ -53,33 +86,3 @@ export default function FormInput({
     </View>
   );
 }
-
-const styles = StyleSheet.create({
-  container: {
-    marginBottom: 4,
-  },
-  label: {
-    fontSize: 14,
-    fontFamily: 'Roboto-Medium',
-    color: '#374151',
-    marginBottom: 8,
-  },
-  required: {
-    color: '#ef4444',
-  },
-  input: {
-    backgroundColor: '#ffffff',
-    borderWidth: 1,
-    borderColor: '#d1d5db',
-    borderRadius: 12,
-    paddingHorizontal: 16,
-    paddingVertical: 12,
-    fontSize: 16,
-    fontFamily: 'Roboto-Regular',
-    color: '#1f2937',
-  },
-  multilineInput: {
-    paddingTop: 12,
-    textAlignVertical: 'top',
-  },
-});

--- a/components/FormSelect.tsx
+++ b/components/FormSelect.tsx
@@ -1,6 +1,7 @@
-import React, { useState } from 'react';
+import React, { useState, useMemo } from 'react';
 import { View, Text, TouchableOpacity, StyleSheet, Modal, ScrollView } from 'react-native';
 import { ChevronDown, Check } from 'lucide-react-native';
+import { useTheme } from '@/contexts/ThemeContext';
 
 interface FormSelectProps {
   label: string;
@@ -12,6 +13,76 @@ interface FormSelectProps {
 
 export default function FormSelect({ label, value, onValueChange, options, required }: FormSelectProps) {
   const [isVisible, setIsVisible] = useState(false);
+  const { colors } = useTheme();
+
+  const styles = useMemo(
+    () =>
+      StyleSheet.create({
+        container: { marginBottom: 4 },
+        label: {
+          fontSize: 14,
+          fontFamily: 'Roboto-Medium',
+          color: colors.label ?? colors.textSecondary,
+          marginBottom: 8,
+        },
+        required: { color: colors.danger },
+        selector: {
+          backgroundColor: colors.card,
+          borderWidth: 1,
+          borderColor: colors.borderAlt,
+          borderRadius: 12,
+          paddingHorizontal: 16,
+          paddingVertical: 12,
+          flexDirection: 'row',
+          alignItems: 'center',
+          justifyContent: 'space-between',
+        },
+        selectorText: {
+          fontSize: 16,
+          fontFamily: 'Roboto-Regular',
+          color: colors.textPrimary,
+        },
+        placeholder: { color: colors.textMuted },
+        overlay: {
+          flex: 1,
+          backgroundColor: 'rgba(0, 0, 0, 0.5)',
+          justifyContent: 'flex-end',
+        },
+        modal: {
+          backgroundColor: colors.card,
+          borderTopLeftRadius: 20,
+          borderTopRightRadius: 20,
+          maxHeight: '50%',
+        },
+        modalHeader: {
+          padding: 20,
+          borderBottomWidth: 1,
+          borderBottomColor: colors.border,
+        },
+        modalTitle: {
+          fontSize: 18,
+          fontFamily: 'Roboto-Bold',
+          color: colors.textPrimary,
+          textAlign: 'center',
+        },
+        optionsList: { maxHeight: 300 },
+        option: {
+          paddingHorizontal: 20,
+          paddingVertical: 16,
+          flexDirection: 'row',
+          alignItems: 'center',
+          justifyContent: 'space-between',
+          borderBottomWidth: 1,
+          borderBottomColor: colors.surfaceMuted,
+        },
+        optionText: {
+          fontSize: 16,
+          fontFamily: 'Roboto-Regular',
+          color: colors.textPrimary,
+        },
+      }),
+    [colors]
+  );
 
   const handleSelect = (selectedValue: string) => {
     onValueChange(selectedValue);
@@ -29,7 +100,7 @@ export default function FormSelect({ label, value, onValueChange, options, requi
         <Text style={[styles.selectorText, !value && styles.placeholder]}>
           {value || 'Sélectionner...'}
         </Text>
-        <ChevronDown size={20} color="#6b7280" />
+        <ChevronDown size={20} color={colors.textSecondary} />
       </TouchableOpacity>
 
       <Modal
@@ -56,7 +127,7 @@ export default function FormSelect({ label, value, onValueChange, options, requi
                 >
                   <Text style={styles.optionText}>{option}</Text>
                   {value === option && (
-                    <Check size={20} color="#1e40af" />
+                    <Check size={20} color={colors.primary} />
                   )}
                 </TouchableOpacity>
               ))}
@@ -67,76 +138,3 @@ export default function FormSelect({ label, value, onValueChange, options, requi
     </View>
   );
 }
-
-const styles = StyleSheet.create({
-  container: {
-    marginBottom: 4,
-  },
-  label: {
-    fontSize: 14,
-    fontFamily: 'Roboto-Medium',
-    color: '#374151',
-    marginBottom: 8,
-  },
-  required: {
-    color: '#ef4444',
-  },
-  selector: {
-    backgroundColor: '#ffffff',
-    borderWidth: 1,
-    borderColor: '#d1d5db',
-    borderRadius: 12,
-    paddingHorizontal: 16,
-    paddingVertical: 12,
-    flexDirection: 'row',
-    alignItems: 'center',
-    justifyContent: 'space-between',
-  },
-  selectorText: {
-    fontSize: 16,
-    fontFamily: 'Roboto-Regular',
-    color: '#1f2937',
-  },
-  placeholder: {
-    color: '#9ca3af',
-  },
-  overlay: {
-    flex: 1,
-    backgroundColor: 'rgba(0, 0, 0, 0.5)',
-    justifyContent: 'flex-end',
-  },
-  modal: {
-    backgroundColor: '#ffffff',
-    borderTopLeftRadius: 20,
-    borderTopRightRadius: 20,
-    maxHeight: '50%',
-  },
-  modalHeader: {
-    padding: 20,
-    borderBottomWidth: 1,
-    borderBottomColor: '#e5e7eb',
-  },
-  modalTitle: {
-    fontSize: 18,
-    fontFamily: 'Roboto-Bold',
-    color: '#1f2937',
-    textAlign: 'center',
-  },
-  optionsList: {
-    maxHeight: 300,
-  },
-  option: {
-    paddingHorizontal: 20,
-    paddingVertical: 16,
-    flexDirection: 'row',
-    alignItems: 'center',
-    justifyContent: 'space-between',
-    borderBottomWidth: 1,
-    borderBottomColor: '#f3f4f6',
-  },
-  optionText: {
-    fontSize: 16,
-    fontFamily: 'Roboto-Regular',
-    color: '#1f2937',
-  },
-});

--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -1,6 +1,7 @@
-import React from 'react';
+import React, { useMemo } from 'react';
 import { View, Text, StyleSheet, Platform } from 'react-native';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
+import { useTheme } from '@/contexts/ThemeContext';
 
 interface HeaderProps {
   title: string;
@@ -9,6 +10,34 @@ interface HeaderProps {
 
 export default function Header({ title, subtitle }: HeaderProps) {
   const insets = useSafeAreaInsets();
+  const { colors } = useTheme();
+
+  const styles = useMemo(
+    () =>
+      StyleSheet.create({
+        header: {
+          backgroundColor: colors.primary,
+          paddingBottom: 20,
+        },
+        content: {
+          paddingHorizontal: 20,
+          paddingTop: 16,
+        },
+        title: {
+          fontSize: 28,
+          fontFamily: 'Roboto-Bold',
+          color: colors.card,
+          marginBottom: 4,
+        },
+        subtitle: {
+          fontSize: 16,
+          fontFamily: 'Roboto-Regular',
+          color: '#bfdbfe',
+          opacity: 0.9,
+        },
+      }),
+    [colors]
+  );
 
   return (
     <View style={[styles.header, { paddingTop: insets.top }]}>
@@ -19,26 +48,3 @@ export default function Header({ title, subtitle }: HeaderProps) {
     </View>
   );
 }
-
-const styles = StyleSheet.create({
-  header: {
-    backgroundColor: '#1e40af',
-    paddingBottom: 20,
-  },
-  content: {
-    paddingHorizontal: 20,
-    paddingTop: 16,
-  },
-  title: {
-    fontSize: 28,
-    fontFamily: 'Roboto-Bold',
-    color: '#ffffff',
-    marginBottom: 4,
-  },
-  subtitle: {
-    fontSize: 16,
-    fontFamily: 'Roboto-Regular',
-    color: '#bfdbfe',
-    opacity: 0.9,
-  },
-});

--- a/components/LetterCard.tsx
+++ b/components/LetterCard.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useMemo } from 'react';
 import { View, Text, StyleSheet, TouchableOpacity, Alert, Share } from 'react-native';
 import { Share as ShareIcon, FileDown, Trash2, Eye } from 'lucide-react-native';
 import { router } from 'expo-router';
@@ -8,6 +8,7 @@ import * as Sharing from 'expo-sharing';
 import { Letter } from '@/types/letter';
 import { LETTER_TYPES } from '@/constants/letterTypes';
 import ActionButton from '@/components/ActionButton';
+import { useTheme } from '@/contexts/ThemeContext';
 
 interface LetterCardProps {
   letter: Letter;
@@ -16,6 +17,86 @@ interface LetterCardProps {
 
 export default function LetterCard({ letter, onDelete }: LetterCardProps) {
   const letterTypeInfo = LETTER_TYPES.find(type => type.type === letter.type);
+  const { colors } = useTheme();
+
+  const styles = useMemo(
+    () =>
+      StyleSheet.create({
+        card: {
+          backgroundColor: colors.card,
+          borderRadius: 16,
+          padding: 20,
+          shadowColor: colors.shadow,
+          shadowOffset: { width: 0, height: 2 },
+          shadowOpacity: 0.1,
+          shadowRadius: 8,
+          elevation: 4,
+        },
+        header: {
+          flexDirection: 'row',
+          justifyContent: 'space-between',
+          alignItems: 'center',
+          marginBottom: 12,
+        },
+        letterInfo: {
+          flexDirection: 'row',
+          alignItems: 'center',
+          gap: 12,
+        },
+        typeBadge: {
+          paddingHorizontal: 12,
+          paddingVertical: 4,
+          borderRadius: 20,
+        },
+        typeText: {
+          fontSize: 12,
+          fontFamily: 'Roboto-Medium',
+        },
+        date: {
+          fontSize: 12,
+          fontFamily: 'Roboto-Regular',
+          color: colors.textSecondary,
+        },
+        title: {
+          fontSize: 16,
+          fontFamily: 'Roboto-Bold',
+          color: colors.textPrimary,
+          marginBottom: 12,
+        },
+        recipientInfo: { marginBottom: 16 },
+        recipientLabel: {
+          fontSize: 12,
+          fontFamily: 'Roboto-Medium',
+          color: colors.textSecondary,
+          marginBottom: 4,
+        },
+        recipientText: {
+          fontSize: 14,
+          fontFamily: 'Roboto-Medium',
+          color: colors.textPrimary,
+        },
+        recipientAddress: {
+          fontSize: 12,
+          fontFamily: 'Roboto-Regular',
+          color: colors.textSecondary,
+        },
+        actions: {
+          flexDirection: 'row',
+          justifyContent: 'flex-end',
+          gap: 8,
+        },
+        actionButton: {
+          width: 40,
+          height: 40,
+          borderRadius: 20,
+          backgroundColor: colors.background,
+          alignItems: 'center',
+          justifyContent: 'center',
+        },
+        deleteButton: { backgroundColor: colors.danger + '20' },
+      }),
+    [colors]
+  );
   
   const handleShare = async () => {
     try {
@@ -78,103 +159,21 @@ export default function LetterCard({ letter, onDelete }: LetterCardProps) {
       
       <View style={styles.actions}>
         <TouchableOpacity style={styles.actionButton} onPress={handleView}>
-          <Eye size={18} color="#6b7280" />
+          <Eye size={18} color={colors.textSecondary} />
         </TouchableOpacity>
         
         <TouchableOpacity style={styles.actionButton} onPress={handleShare}>
-          <ShareIcon size={18} color="#6b7280" />
+          <ShareIcon size={18} color={colors.textSecondary} />
         </TouchableOpacity>
         
         <TouchableOpacity style={styles.actionButton} onPress={handleDownload}>
-          <FileDown size={18} color="#6b7280" />
+          <FileDown size={18} color={colors.textSecondary} />
         </TouchableOpacity>
         
         <TouchableOpacity style={[styles.actionButton, styles.deleteButton]} onPress={onDelete}>
-          <Trash2 size={18} color="#ef4444" />
+          <Trash2 size={18} color={colors.danger} />
         </TouchableOpacity>
       </View>
     </View>
   );
 }
-
-const styles = StyleSheet.create({
-  card: {
-    backgroundColor: '#ffffff',
-    borderRadius: 16,
-    padding: 20,
-    shadowColor: '#000',
-    shadowOffset: {
-      width: 0,
-      height: 2,
-    },
-    shadowOpacity: 0.1,
-    shadowRadius: 8,
-    elevation: 4,
-  },
-  header: {
-    flexDirection: 'row',
-    justifyContent: 'space-between',
-    alignItems: 'center',
-    marginBottom: 12,
-  },
-  letterInfo: {
-    flexDirection: 'row',
-    alignItems: 'center',
-    gap: 12,
-  },
-  typeBadge: {
-    paddingHorizontal: 12,
-    paddingVertical: 4,
-    borderRadius: 20,
-  },
-  typeText: {
-    fontSize: 12,
-    fontFamily: 'Roboto-Medium',
-  },
-  date: {
-    fontSize: 12,
-    fontFamily: 'Roboto-Regular',
-    color: '#6b7280',
-  },
-  title: {
-    fontSize: 16,
-    fontFamily: 'Roboto-Bold',
-    color: '#1f2937',
-    marginBottom: 12,
-  },
-  recipientInfo: {
-    marginBottom: 16,
-  },
-  recipientLabel: {
-    fontSize: 12,
-    fontFamily: 'Roboto-Medium',
-    color: '#6b7280',
-    marginBottom: 4,
-  },
-  recipientText: {
-    fontSize: 14,
-    fontFamily: 'Roboto-Medium',
-    color: '#1f2937',
-  },
-  recipientAddress: {
-    fontSize: 12,
-    fontFamily: 'Roboto-Regular',
-    color: '#6b7280',
-  },
-  actions: {
-    flexDirection: 'row',
-    justifyContent: 'flex-end',
-    gap: 8,
-  },
-  actionButton: {
-    width: 40,
-    height: 40,
-    borderRadius: 20,
-    backgroundColor: '#f8fafc',
-    alignItems: 'center',
-    justifyContent: 'center',
-  },
-  deleteButton: {
-    backgroundColor: '#fef2f2',
-  },
-});

--- a/components/LetterFieldsForm.tsx
+++ b/components/LetterFieldsForm.tsx
@@ -1,5 +1,6 @@
-import React from 'react';
+import React, { useMemo } from 'react';
 import { View, Text, StyleSheet } from 'react-native';
+import { useTheme } from '@/contexts/ThemeContext';
 import { LetterType } from '@/types/letter';
 import { LETTER_TYPES } from '@/constants/letterTypes';
 import FormInput from '@/components/FormInput';
@@ -14,6 +15,22 @@ interface LetterFieldsFormProps {
 
 export default function LetterFieldsForm({ letterType, values, onUpdateValues }: LetterFieldsFormProps) {
   const letterTypeInfo = LETTER_TYPES.find(type => type.type === letterType);
+  const { colors } = useTheme();
+
+  const styles = useMemo(
+    () =>
+      StyleSheet.create({
+        container: { marginBottom: 8 },
+        title: {
+          fontSize: 18,
+          fontFamily: 'Roboto-Bold',
+          color: colors.textPrimary,
+          marginBottom: 16,
+        },
+        form: { gap: 16 },
+      }),
+    [colors]
+  );
   
   if (!letterTypeInfo) return null;
 
@@ -90,18 +107,3 @@ export default function LetterFieldsForm({ letterType, values, onUpdateValues }:
     </View>
   );
 }
-
-const styles = StyleSheet.create({
-  container: {
-    marginBottom: 8,
-  },
-  title: {
-    fontSize: 18,
-    fontFamily: 'Roboto-Bold',
-    color: '#1f2937',
-    marginBottom: 16,
-  },
-  form: {
-    gap: 16,
-  },
-});

--- a/components/LetterTypeSelector.tsx
+++ b/components/LetterTypeSelector.tsx
@@ -1,8 +1,9 @@
-import React from 'react';
+import React, { useMemo } from 'react';
 import { View, Text, StyleSheet, TouchableOpacity, ScrollView } from 'react-native';
 import { LetterType } from '@/types/letter';
 import { LETTER_TYPES } from '@/constants/letterTypes';
 import * as Icons from 'lucide-react-native';
+import { useTheme } from '@/contexts/ThemeContext';
 
 interface LetterTypeSelectorProps {
   selectedType: LetterType | null;
@@ -10,6 +11,65 @@ interface LetterTypeSelectorProps {
 }
 
 export default function LetterTypeSelector({ selectedType, onSelectType }: LetterTypeSelectorProps) {
+  const { colors } = useTheme();
+
+  const styles = useMemo(
+    () =>
+      StyleSheet.create({
+        container: { marginBottom: 8 },
+        title: {
+          fontSize: 18,
+          fontFamily: 'Roboto-Bold',
+          color: colors.textPrimary,
+          marginBottom: 16,
+        },
+        scrollContainer: { marginHorizontal: -4 },
+        typeGrid: { flexDirection: 'row', paddingHorizontal: 4, gap: 12 },
+        typeCard: {
+          backgroundColor: colors.card,
+          borderRadius: 16,
+          padding: 16,
+          width: 180,
+          borderLeftWidth: 4,
+          shadowColor: colors.shadow,
+          shadowOffset: { width: 0, height: 2 },
+          shadowOpacity: 0.1,
+          shadowRadius: 8,
+          elevation: 4,
+        },
+        selectedCard: {
+          backgroundColor: colors.highlight,
+          borderColor: colors.primary,
+          borderWidth: 2,
+          borderLeftWidth: 4,
+        },
+        iconContainer: {
+          width: 48,
+          height: 48,
+          borderRadius: 12,
+          alignItems: 'center',
+          justifyContent: 'center',
+          marginBottom: 12,
+        },
+        typeContent: { flex: 1 },
+        typeTitle: {
+          fontSize: 16,
+          fontFamily: 'Roboto-Bold',
+          color: colors.textPrimary,
+          marginBottom: 6,
+        },
+        typeDescription: {
+          fontSize: 13,
+          fontFamily: 'Roboto-Regular',
+          color: '#64748b',
+          lineHeight: 18,
+        },
+        selectedText: { color: colors.primary },
+        selectedDescription: { color: colors.primary, opacity: 0.8 },
+      }),
+    [colors]
+  );
+
   return (
     <View style={styles.container}>
       <Text style={styles.title}>Type de courrier</Text>
@@ -49,74 +109,3 @@ export default function LetterTypeSelector({ selectedType, onSelectType }: Lette
     </View>
   );
 }
-
-const styles = StyleSheet.create({
-  container: {
-    marginBottom: 8,
-  },
-  title: {
-    fontSize: 18,
-    fontFamily: 'Roboto-Bold',
-    color: '#1f2937',
-    marginBottom: 16,
-  },
-  scrollContainer: {
-    marginHorizontal: -4,
-  },
-  typeGrid: {
-    flexDirection: 'row',
-    paddingHorizontal: 4,
-    gap: 12,
-  },
-  typeCard: {
-    backgroundColor: '#ffffff',
-    borderRadius: 16,
-    padding: 16,
-    width: 180,
-    borderLeftWidth: 4,
-    shadowColor: '#000',
-    shadowOffset: {
-      width: 0,
-      height: 2,
-    },
-    shadowOpacity: 0.1,
-    shadowRadius: 8,
-    elevation: 4,
-  },
-  selectedCard: {
-    backgroundColor: '#f0f9ff',
-    borderColor: '#1e40af',
-    borderWidth: 2,
-    borderLeftWidth: 4,
-  },
-  iconContainer: {
-    width: 48,
-    height: 48,
-    borderRadius: 12,
-    alignItems: 'center',
-    justifyContent: 'center',
-    marginBottom: 12,
-  },
-  typeContent: {
-    flex: 1,
-  },
-  typeTitle: {
-    fontSize: 16,
-    fontFamily: 'Roboto-Bold',
-    color: '#1f2937',
-    marginBottom: 6,
-  },
-  typeDescription: {
-    fontSize: 13,
-    fontFamily: 'Roboto-Regular',
-    color: '#64748b',
-    lineHeight: 18,
-  },
-  selectedText: {
-    color: '#1e40af',
-  },
-  selectedDescription: {
-    color: '#1e40af',
-    opacity: 0.8,
-  },
-});

--- a/components/LoadingOverlay.tsx
+++ b/components/LoadingOverlay.tsx
@@ -1,20 +1,28 @@
-import React from 'react';
+import React, { useMemo } from 'react';
 import { View, ActivityIndicator, StyleSheet } from 'react-native';
+import { useTheme } from '@/contexts/ThemeContext';
 
 export default function LoadingOverlay() {
+  const { colors } = useTheme();
+
+  const styles = useMemo(
+    () =>
+      StyleSheet.create({
+        overlay: {
+          ...StyleSheet.absoluteFillObject,
+          backgroundColor: 'rgba(255, 255, 255, 0.8)',
+          alignItems: 'center',
+          justifyContent: 'center',
+          zIndex: 999,
+        },
+      }),
+    [colors]
+  );
+
   return (
     <View style={styles.overlay} pointerEvents="auto">
-      <ActivityIndicator size="large" color="#1e40af" />
+      <ActivityIndicator size="large" color={colors.primary} />
     </View>
   );
 }
 
-const styles = StyleSheet.create({
-  overlay: {
-    ...StyleSheet.absoluteFillObject,
-    backgroundColor: 'rgba(255, 255, 255, 0.8)',
-    alignItems: 'center',
-    justifyContent: 'center',
-    zIndex: 999,
-  },
-});

--- a/components/ProfileSection.tsx
+++ b/components/ProfileSection.tsx
@@ -1,10 +1,11 @@
-import React, { useState } from 'react';
+import React, { useState, useMemo } from 'react';
 import { View, Text, StyleSheet, TouchableOpacity, Image, Alert } from 'react-native';
 import { Camera, User, CreditCard as Edit } from 'lucide-react-native';
 import * as ImagePicker from 'expo-image-picker';
 import { UserProfile } from '@/types/letter';
 import FormInput from '@/components/FormInput';
 import ActionButton from '@/components/ActionButton';
+import { useTheme } from '@/contexts/ThemeContext';
 
 interface ProfileSectionProps {
   profile: UserProfile | null;
@@ -14,6 +15,79 @@ interface ProfileSectionProps {
 
 export default function ProfileSection({ profile, onUpdateProfile, loading }: ProfileSectionProps) {
   const [isEditing, setIsEditing] = useState(false);
+  const { colors } = useTheme();
+  const styles = useMemo(
+    () =>
+      StyleSheet.create({
+        container: { marginBottom: 8 },
+        header: {
+          flexDirection: 'row',
+          justifyContent: 'space-between',
+          alignItems: 'center',
+          marginBottom: 16,
+        },
+        title: {
+          fontSize: 18,
+          fontFamily: 'Roboto-Bold',
+          color: colors.textPrimary,
+        },
+        editButton: {
+          width: 40,
+          height: 40,
+          borderRadius: 20,
+          backgroundColor: colors.highlight,
+          alignItems: 'center',
+          justifyContent: 'center',
+        },
+        card: {
+          backgroundColor: colors.card,
+          borderRadius: 16,
+          padding: 20,
+          shadowColor: colors.shadow,
+          shadowOffset: { width: 0, height: 2 },
+          shadowOpacity: 0.1,
+          shadowRadius: 8,
+          elevation: 4,
+        },
+        loadingCard: {
+          backgroundColor: colors.card,
+          borderRadius: 16,
+          height: 200,
+        },
+        photoSection: { alignItems: 'center', marginBottom: 24 },
+        photoContainer: { marginBottom: 12 },
+        photo: { width: 80, height: 80, borderRadius: 40 },
+        photoPlaceholder: {
+          width: 80,
+          height: 80,
+          borderRadius: 40,
+          backgroundColor: colors.surfaceMuted,
+          alignItems: 'center',
+          justifyContent: 'center',
+        },
+        photoButton: {
+          flexDirection: 'row',
+          alignItems: 'center',
+          gap: 6,
+          paddingHorizontal: 12,
+          paddingVertical: 6,
+          borderRadius: 16,
+          backgroundColor: colors.highlight,
+        },
+        photoButtonText: {
+          fontSize: 12,
+          fontFamily: 'Roboto-Medium',
+          color: colors.primary,
+        },
+        form: { gap: 16 },
+        row: { flexDirection: 'row', gap: 12 },
+        halfInput: { flex: 1 },
+        smallInput: { flex: 0.3 },
+        largeInput: { flex: 0.7 },
+        actions: { marginTop: 24, gap: 12 },
+      }),
+    [colors]
+  );
   const [editedProfile, setEditedProfile] = useState<UserProfile>(
     profile || {
       firstName: '',
@@ -204,100 +278,3 @@ export default function ProfileSection({ profile, onUpdateProfile, loading }: Pr
     </View>
   );
 }
-
-const styles = StyleSheet.create({
-  container: {
-    marginBottom: 8,
-  },
-  header: {
-    flexDirection: 'row',
-    justifyContent: 'space-between',
-    alignItems: 'center',
-    marginBottom: 16,
-  },
-  title: {
-    fontSize: 18,
-    fontFamily: 'Roboto-Bold',
-    color: '#1f2937',
-  },
-  editButton: {
-    width: 40,
-    height: 40,
-    borderRadius: 20,
-    backgroundColor: '#f0f9ff',
-    alignItems: 'center',
-    justifyContent: 'center',
-  },
-  card: {
-    backgroundColor: '#ffffff',
-    borderRadius: 16,
-    padding: 20,
-    shadowColor: '#000',
-    shadowOffset: {
-      width: 0,
-      height: 2,
-    },
-    shadowOpacity: 0.1,
-    shadowRadius: 8,
-    elevation: 4,
-  },
-  loadingCard: {
-    backgroundColor: '#ffffff',
-    borderRadius: 16,
-    height: 200,
-  },
-  photoSection: {
-    alignItems: 'center',
-    marginBottom: 24,
-  },
-  photoContainer: {
-    marginBottom: 12,
-  },
-  photo: {
-    width: 80,
-    height: 80,
-    borderRadius: 40,
-  },
-  photoPlaceholder: {
-    width: 80,
-    height: 80,
-    borderRadius: 40,
-    backgroundColor: '#f3f4f6',
-    alignItems: 'center',
-    justifyContent: 'center',
-  },
-  photoButton: {
-    flexDirection: 'row',
-    alignItems: 'center',
-    gap: 6,
-    paddingHorizontal: 12,
-    paddingVertical: 6,
-    borderRadius: 16,
-    backgroundColor: '#f0f9ff',
-  },
-  photoButtonText: {
-    fontSize: 12,
-    fontFamily: 'Roboto-Medium',
-    color: '#1e40af',
-  },
-  form: {
-    gap: 16,
-  },
-  row: {
-    flexDirection: 'row',
-    gap: 12,
-  },
-  halfInput: {
-    flex: 1,
-  },
-  smallInput: {
-    flex: 0.3,
-  },
-  largeInput: {
-    flex: 0.7,
-  },
-  actions: {
-    marginTop: 24,
-    gap: 12,
-  },
-});

--- a/components/RecipientForm.tsx
+++ b/components/RecipientForm.tsx
@@ -1,5 +1,6 @@
-import React from 'react';
+import React, { useMemo } from 'react';
 import { View, Text, StyleSheet } from 'react-native';
+import { useTheme } from '@/contexts/ThemeContext';
 import { Recipient } from '@/types/letter';
 import FormInput from '@/components/FormInput';
 
@@ -15,6 +16,26 @@ export default function RecipientForm({ recipient, onUpdateRecipient }: Recipien
       [field]: value,
     });
   };
+
+  const { colors } = useTheme();
+  const styles = useMemo(
+    () =>
+      StyleSheet.create({
+        container: { marginBottom: 8 },
+        title: {
+          fontSize: 18,
+          fontFamily: 'Roboto-Bold',
+          color: colors.textPrimary,
+          marginBottom: 16,
+        },
+        form: { gap: 16 },
+        row: { flexDirection: 'row', gap: 12 },
+        halfInput: { flex: 1 },
+        smallInput: { flex: 0.3 },
+        largeInput: { flex: 0.7 },
+      }),
+    [colors]
+  );
 
   return (
     <View style={styles.container}>
@@ -93,31 +114,3 @@ export default function RecipientForm({ recipient, onUpdateRecipient }: Recipien
     </View>
   );
 }
-
-const styles = StyleSheet.create({
-  container: {
-    marginBottom: 8,
-  },
-  title: {
-    fontSize: 18,
-    fontFamily: 'Roboto-Bold',
-    color: '#1f2937',
-    marginBottom: 16,
-  },
-  form: {
-    gap: 16,
-  },
-  row: {
-    flexDirection: 'row',
-    gap: 12,
-  },
-  halfInput: {
-    flex: 1,
-  },
-  smallInput: {
-    flex: 0.3,
-  },
-  largeInput: {
-    flex: 0.7,
-  },
-});

--- a/components/SettingsSection.tsx
+++ b/components/SettingsSection.tsx
@@ -1,6 +1,7 @@
-import React from 'react';
+import React, { useMemo } from 'react';
 import { View, Text, StyleSheet, TouchableOpacity, Linking, Alert } from 'react-native';
 import { ExternalLink, Shield, FileText, Info, RotateCcw, Globe } from 'lucide-react-native';
+import { useTheme } from '@/contexts/ThemeContext';
 
 interface SettingsSectionProps {
   onResetProfile: () => void;
@@ -55,6 +56,76 @@ export default function SettingsSection({ onResetProfile }: SettingsSectionProps
     },
   ];
 
+  const { colors } = useTheme();
+  const styles = useMemo(
+    () =>
+      StyleSheet.create({
+        container: { marginBottom: 32 },
+        title: {
+          fontSize: 18,
+          fontFamily: 'Roboto-Bold',
+          color: colors.textPrimary,
+          marginBottom: 16,
+        },
+        card: {
+          backgroundColor: colors.card,
+          borderRadius: 16,
+          marginBottom: 16,
+          shadowColor: colors.shadow,
+          shadowOffset: { width: 0, height: 2 },
+          shadowOpacity: 0.1,
+          shadowRadius: 8,
+          elevation: 4,
+        },
+        settingItem: {
+          flexDirection: 'row',
+          alignItems: 'center',
+          padding: 16,
+        },
+        borderBottom: {
+          borderBottomWidth: 1,
+          borderBottomColor: colors.surfaceMuted,
+        },
+        settingIcon: {
+          width: 40,
+          height: 40,
+          borderRadius: 20,
+          backgroundColor: colors.background,
+          alignItems: 'center',
+          justifyContent: 'center',
+          marginRight: 12,
+        },
+        dangerousIcon: { backgroundColor: colors.danger + '20' },
+        settingContent: { flex: 1 },
+        settingTitle: {
+          fontSize: 16,
+          fontFamily: 'Roboto-Medium',
+          color: colors.textPrimary,
+          marginBottom: 2,
+        },
+        dangerousText: { color: colors.danger },
+        settingDescription: {
+          fontSize: 13,
+          fontFamily: 'Roboto-Regular',
+          color: colors.textSecondary,
+        },
+        versionInfo: { alignItems: 'center', paddingVertical: 20 },
+        versionText: {
+          fontSize: 14,
+          fontFamily: 'Roboto-Medium',
+          color: colors.textSecondary,
+          marginBottom: 4,
+        },
+        versionSubtext: {
+          fontSize: 12,
+          fontFamily: 'Roboto-Regular',
+          color: colors.textMuted,
+          textAlign: 'center',
+        },
+      }),
+    [colors]
+  );
+
   return (
     <View style={styles.container}>
       <Text style={styles.title}>Paramètres</Text>
@@ -69,13 +140,13 @@ export default function SettingsSection({ onResetProfile }: SettingsSectionProps
               onPress={item.onPress}
             >
               <View style={styles.settingIcon}>
-                <IconComponent size={20} color="#6b7280" />
+                <IconComponent size={20} color={colors.textSecondary} />
               </View>
               <View style={styles.settingContent}>
                 <Text style={styles.settingTitle}>{item.title}</Text>
                 <Text style={styles.settingDescription}>{item.description}</Text>
               </View>
-              <ExternalLink size={16} color="#9ca3af" />
+              <ExternalLink size={16} color={colors.textMuted} />
             </TouchableOpacity>
           );
         })}
@@ -91,7 +162,7 @@ export default function SettingsSection({ onResetProfile }: SettingsSectionProps
               onPress={item.onPress}
             >
               <View style={[styles.settingIcon, item.dangerous && styles.dangerousIcon]}>
-                <IconComponent size={20} color={item.dangerous ? "#ef4444" : "#6b7280"} />
+                <IconComponent size={20} color={item.dangerous ? colors.danger : colors.textSecondary} />
               </View>
               <View style={styles.settingContent}>
                 <Text style={[styles.settingTitle, item.dangerous && styles.dangerousText]}>
@@ -113,82 +184,3 @@ export default function SettingsSection({ onResetProfile }: SettingsSectionProps
     </View>
   );
 }
-
-const styles = StyleSheet.create({
-  container: {
-    marginBottom: 32,
-  },
-  title: {
-    fontSize: 18,
-    fontFamily: 'Roboto-Bold',
-    color: '#1f2937',
-    marginBottom: 16,
-  },
-  card: {
-    backgroundColor: '#ffffff',
-    borderRadius: 16,
-    marginBottom: 16,
-    shadowColor: '#000',
-    shadowOffset: {
-      width: 0,
-      height: 2,
-    },
-    shadowOpacity: 0.1,
-    shadowRadius: 8,
-    elevation: 4,
-  },
-  settingItem: {
-    flexDirection: 'row',
-    alignItems: 'center',
-    padding: 16,
-  },
-  borderBottom: {
-    borderBottomWidth: 1,
-    borderBottomColor: '#f3f4f6',
-  },
-  settingIcon: {
-    width: 40,
-    height: 40,
-    borderRadius: 20,
-    backgroundColor: '#f8fafc',
-    alignItems: 'center',
-    justifyContent: 'center',
-    marginRight: 12,
-  },
-  dangerousIcon: {
-    backgroundColor: '#fef2f2',
-  },
-  settingContent: {
-    flex: 1,
-  },
-  settingTitle: {
-    fontSize: 16,
-    fontFamily: 'Roboto-Medium',
-    color: '#1f2937',
-    marginBottom: 2,
-  },
-  dangerousText: {
-    color: '#ef4444',
-  },
-  settingDescription: {
-    fontSize: 13,
-    fontFamily: 'Roboto-Regular',
-    color: '#6b7280',
-  },
-  versionInfo: {
-    alignItems: 'center',
-    paddingVertical: 20,
-  },
-  versionText: {
-    fontSize: 14,
-    fontFamily: 'Roboto-Medium',
-    color: '#6b7280',
-    marginBottom: 4,
-  },
-  versionSubtext: {
-    fontSize: 12,
-    fontFamily: 'Roboto-Regular',
-    color: '#9ca3af',
-    textAlign: 'center',
-  },
-});

--- a/components/StatsCard.tsx
+++ b/components/StatsCard.tsx
@@ -1,6 +1,7 @@
-import React from 'react';
+import React, { useMemo } from 'react';
 import { View, Text, StyleSheet, TouchableOpacity } from 'react-native';
 import type { LucideIcon } from 'lucide-react-native';
+import { useTheme } from '@/contexts/ThemeContext';
 
 interface StatsCardProps {
   title: string;
@@ -10,14 +11,60 @@ interface StatsCardProps {
   onPress?: () => void;
 }
 
-export default function StatsCard({ 
-  title, 
-  value, 
-  icon: Icon, 
+export default function StatsCard({
+  title,
+  value,
+  icon: Icon,
   color = '#1e40af',
-  onPress 
+  onPress
 }: StatsCardProps) {
   const Component = onPress ? TouchableOpacity : View;
+  const { colors } = useTheme();
+
+  const styles = useMemo(
+    () =>
+      StyleSheet.create({
+        card: {
+          backgroundColor: colors.card,
+          borderRadius: 16,
+          padding: 20,
+          flex: 1,
+          marginHorizontal: 6,
+          shadowColor: colors.shadow,
+          shadowOffset: { width: 0, height: 2 },
+          shadowOpacity: 0.1,
+          shadowRadius: 8,
+          elevation: 4,
+        },
+        content: { alignItems: 'flex-start' },
+        header: {
+          flexDirection: 'row',
+          alignItems: 'center',
+          justifyContent: 'space-between',
+          width: '100%',
+          marginBottom: 12,
+        },
+        iconContainer: {
+          width: 48,
+          height: 48,
+          borderRadius: 12,
+          alignItems: 'center',
+          justifyContent: 'center',
+        },
+        value: {
+          fontSize: 28,
+          fontFamily: 'Roboto-Bold',
+          color: colors.textPrimary,
+        },
+        title: {
+          fontSize: 14,
+          fontFamily: 'Roboto-Medium',
+          color: colors.textSecondary,
+          lineHeight: 20,
+        },
+      }),
+    [colors]
+  );
 
   return (
     <Component style={styles.card} onPress={onPress}>
@@ -33,49 +80,3 @@ export default function StatsCard({
     </Component>
   );
 }
-
-const styles = StyleSheet.create({
-  card: {
-    backgroundColor: '#ffffff',
-    borderRadius: 16,
-    padding: 20,
-    flex: 1,
-    marginHorizontal: 6,
-    shadowColor: '#000',
-    shadowOffset: {
-      width: 0,
-      height: 2,
-    },
-    shadowOpacity: 0.1,
-    shadowRadius: 8,
-    elevation: 4,
-  },
-  content: {
-    alignItems: 'flex-start',
-  },
-  header: {
-    flexDirection: 'row',
-    alignItems: 'center',
-    justifyContent: 'space-between',
-    width: '100%',
-    marginBottom: 12,
-  },
-  iconContainer: {
-    width: 48,
-    height: 48,
-    borderRadius: 12,
-    alignItems: 'center',
-    justifyContent: 'center',
-  },
-  value: {
-    fontSize: 28,
-    fontFamily: 'Roboto-Bold',
-    color: '#1f2937',
-  },
-  title: {
-    fontSize: 14,
-    fontFamily: 'Roboto-Medium',
-    color: '#64748b',
-    lineHeight: 20,
-  },
-});

--- a/contexts/ThemeContext.tsx
+++ b/contexts/ThemeContext.tsx
@@ -1,0 +1,52 @@
+import React, { createContext, useContext } from 'react';
+
+export type Theme = {
+  background: string;
+  card: string;
+  textPrimary: string;
+  textSecondary: string;
+  textMuted: string;
+  primary: string;
+  success: string;
+  danger: string;
+  border: string;
+  borderAlt: string;
+  highlight: string;
+  surfaceLight: string;
+  surfaceMuted: string;
+  shadow: string;
+};
+
+const lightColors: Theme = {
+  background: '#f8fafc',
+  card: '#ffffff',
+  textPrimary: '#1f2937',
+  textSecondary: '#6b7280',
+  textMuted: '#9ca3af',
+  primary: '#1e40af',
+  success: '#10b981',
+  danger: '#ef4444',
+  border: '#e5e7eb',
+  borderAlt: '#d1d5db',
+  highlight: '#f0f9ff',
+  surfaceLight: '#f1f5f9',
+  surfaceMuted: '#f3f4f6',
+  shadow: '#000',
+};
+
+interface ThemeContextValue {
+  colors: Theme;
+}
+
+const ThemeContext = createContext<ThemeContextValue>({ colors: lightColors });
+
+export const ThemeProvider = ({ children }: React.PropsWithChildren<{}>) => {
+  return (
+    <ThemeContext.Provider value={{ colors: lightColors }}>
+      {children}
+    </ThemeContext.Provider>
+  );
+};
+
+export const useTheme = () => useContext(ThemeContext);
+


### PR DESCRIPTION
## Summary
- add `ThemeContext` with color palette and hook
- wrap root layout with `ThemeProvider`
- compute styles with `useTheme` so colors react to theme changes
- replace hard-coded colors in components and screens with theme variables

## Testing
- `npm run lint` *(fails: No ESLint config; fetch failed)*

------
https://chatgpt.com/codex/tasks/task_e_684eec08acec8320ae4c97c1e5fefdbd