### PR TITLE
Fix missing useMemo import

### DIFF
--- a/app/(tabs)/_layout.tsx
+++ b/app/(tabs)/_layout.tsx
@@ -1,6 +1,7 @@
 import { Tabs } from 'expo-router';
 import { Chrome as Home, FileText, History, Settings } from 'lucide-react-native';
 import { View, StyleSheet, Platform } from 'react-native';
+import { useMemo } from 'react';
 import { useTheme } from '@/contexts/ThemeContext';
 
 export default function TabLayout() {


### PR DESCRIPTION
## Summary
- fix `useMemo` undefined error in tab layout by importing it

## Testing
- `npm run lint` *(fails: fetch failed)*

------
https://chatgpt.com/codex/tasks/task_e_684ef3794f2883209c94ae1bd35bc1a0