### PR TITLE
Add API config helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,8 @@ can copy `.env.example` and adjust the value:
 cp .env.example .env
 ```
 
-If the variable is not provided, the app defaults to
+`utils/apiConfig.ts` reads this value at runtime. If the variable is not
+provided, the helper falls back to `app.json` `extra.API_BASE_URL` and finally to
 `https://assistant-backend-yrbx.onrender.com`.
 
 ## Features
@@ -45,7 +46,7 @@ If the variable is not provided, the app defaults to
 ## Fonctionnement de la génération de courrier
 
 
-Les données renseignées dans les formulaires sont combinées avec le profil utilisateur pour créer un *prompt* envoyé à l'API située à `https://assistant-backend-yrbx.onrender.com`. La fonction `generateLetter` du fichier [`letterService.ts`](services/letterService.ts) se charge de réaliser l'appel réseau puis renvoie le contenu du courrier.
+Les données renseignées dans les formulaires sont combinées avec le profil utilisateur pour créer un *prompt* envoyé à l'API configurée dans `utils/apiConfig.ts`. La fonction `generateLetter` du fichier [`letterService.ts`](services/letterService.ts) se charge de réaliser l'appel réseau puis renvoie le contenu du courrier.
 
 
 - Create letters

--- a/services/letterService.ts
+++ b/services/letterService.ts
@@ -1,7 +1,5 @@
 import { Letter, LetterRequest, UserProfile, Statistics } from '@/types/letter';
-
-const API_BASE_URL =
-  process.env.API_BASE_URL ?? 'https://assistant-backend-yrbx.onrender.com';
+import { API_BASE_URL } from '@/utils/apiConfig';
 
 class LetterService {
   async generateLetter(request: LetterRequest): Promise<string> {

--- a/utils/apiConfig.ts
+++ b/utils/apiConfig.ts
@@ -1,0 +1,6 @@
+import Constants from 'expo-constants';
+
+export const API_BASE_URL =
+  process.env.API_BASE_URL ||
+  (Constants?.expoConfig?.extra?.API_BASE_URL as string | undefined) ||
+  'https://assistant-backend-yrbx.onrender.com';


### PR DESCRIPTION
## Summary
- centralize API base URL in `utils/apiConfig.ts`
- use helper in `letterService.ts`
- document configuration in README

## Testing
- `npm run lint` *(fails: fetch to api.expo.dev blocked)*

------
https://chatgpt.com/codex/tasks/task_e_684fd62fbb8c8320b79dae55e6243168