### PR TITLE
Add ads with optional removal

### DIFF
--- a/app/(tabs)/create.tsx
+++ b/app/(tabs)/create.tsx
@@ -6,6 +6,7 @@ import RecipientForm from '@/components/RecipientForm';
 import LetterFieldsForm from '@/components/LetterFieldsForm';
 import ActionButton from '@/components/ActionButton';
 import LoadingOverlay from '@/components/LoadingOverlay';
+import AdBanner from '@/components/AdBanner';
 import { LetterType, Recipient, UserProfile } from '@/types/letter';
 import { letterService } from '@/services/letterService';
 import { useTheme } from '@/contexts/ThemeContext';
@@ -156,6 +157,7 @@ export default function CreateScreen() {
         )}
       </ScrollView>
       {isGenerating && <LoadingOverlay />}
+      <AdBanner />
     </View>
   );
 }

--- a/app/(tabs)/history.tsx
+++ b/app/(tabs)/history.tsx
@@ -7,6 +7,7 @@ import { Letter } from '@/types/letter';
 import { letterService } from '@/services/letterService';
 import { FileText } from 'lucide-react-native';
 import { useTheme } from '@/contexts/ThemeContext';
+import AdBanner from '@/components/AdBanner';
 
 export default function HistoryScreen() {
   const [letters, setLetters] = useState<Letter[]>([]);
@@ -111,6 +112,7 @@ export default function HistoryScreen() {
           </View>
         )}
       </ScrollView>
+      <AdBanner />
     </View>
   );
 }

--- a/app/(tabs)/index.tsx
+++ b/app/(tabs)/index.tsx
@@ -4,6 +4,7 @@ import { FileText, TrendingUp, Calendar, Users, User } from 'lucide-react-native
 import Header from '@/components/Header';
 import StatsCard from '@/components/StatsCard';
 import ActionButton from '@/components/ActionButton';
+import AdBanner from '@/components/AdBanner';
 import { useTheme } from '@/contexts/ThemeContext';
 import { letterService } from '@/services/letterService';
 import { Statistics, UserProfile } from '@/types/letter';
@@ -204,6 +205,7 @@ export default function HomeScreen() {
           />
         </View>
       </ScrollView>
+      <AdBanner />
     </View>
   );
 }

--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -5,6 +5,7 @@ import { StatusBar } from 'expo-status-bar';
 import { SplashScreen } from 'expo-router';
 import { useFrameworkReady } from '@/hooks/useFrameworkReady';
 import { ThemeProvider, useTheme } from '@/contexts/ThemeContext';
+import { AdsProvider } from '@/contexts/AdsContext';
 
 // Empêche l'écran de chargement de se fermer automatiquement
 SplashScreen.preventAutoHideAsync();
@@ -30,7 +31,9 @@ export default function RootLayout() {
 
   return (
     <ThemeProvider>
-      <RootContent />
+      <AdsProvider>
+        <RootContent />
+      </AdsProvider>
     </ThemeProvider>
   );
 }

--- a/app/letter-preview.tsx
+++ b/app/letter-preview.tsx
@@ -12,6 +12,7 @@ import {
 import { useLocalSearchParams, router } from 'expo-router';
 import Header from '@/components/Header';
 import EmptyState from '@/components/EmptyState';
+import AdBanner from '@/components/AdBanner';
 import {
   FileText,
   ArrowLeft,
@@ -133,6 +134,7 @@ export default function LetterPreviewScreen() {
           <Mail size={18} color={colors.textSecondary} />
         </TouchableOpacity>
       </View>
+      <AdBanner />
     </View>
   );
 }

--- a/components/AdBanner.tsx
+++ b/components/AdBanner.tsx
@@ -1,0 +1,21 @@
+import React from 'react';
+import { View } from 'react-native';
+import { AdMobBanner } from 'expo-ads-admob';
+import { useAds } from '@/contexts/AdsContext';
+
+export default function AdBanner() {
+  const { adsRemoved } = useAds();
+
+  if (adsRemoved) {
+    return null;
+  }
+
+  return (
+    <View>
+      <AdMobBanner
+        bannerSize="smartBannerPortrait"
+        adUnitID="ca-app-pub-3940256099942544/6300978111" // ID de test
+      />
+    </View>
+  );
+}

--- a/components/SettingsSection.tsx
+++ b/components/SettingsSection.tsx
@@ -15,8 +15,10 @@ import {
   Info,
   RotateCcw,
   Moon,
+  CreditCard,
 } from 'lucide-react-native';
 import { useTheme } from '@/contexts/ThemeContext';
+import { useAds } from '@/contexts/AdsContext';
 
 interface SettingsSectionProps {
   onResetProfile: () => void;
@@ -24,6 +26,7 @@ interface SettingsSectionProps {
 
 export default function SettingsSection({ onResetProfile }: SettingsSectionProps) {
   const { theme, toggleTheme, colors } = useTheme();
+  const { adsRemoved, removeAds } = useAds();
 
   const isDarkMode = theme === 'dark';
 
@@ -38,12 +41,40 @@ export default function SettingsSection({ onResetProfile }: SettingsSectionProps
     );
   };
 
+  const handleRemoveAds = () => {
+    if (adsRemoved) {
+      Alert.alert('Achat déjà effectué');
+      return;
+    }
+
+    Alert.alert(
+      'Supprimer la publicité',
+      'Cette action simule un paiement pour retirer les publicités.',
+      [
+        { text: 'Annuler', style: 'cancel' },
+        {
+          text: 'Payer',
+          onPress: async () => {
+            await removeAds();
+            Alert.alert('Merci', 'Les publicités ont été désactivées');
+          },
+        },
+      ]
+    );
+  };
+
   const settingsItems = [
     {
       icon: Shield,
       title: 'Politique de confidentialité',
       description: 'Comment nous protégeons vos données',
       onPress: () => openLink('https://example.com/privacy', 'Politique de confidentialité'),
+    },
+    {
+      icon: CreditCard,
+      title: 'Supprimer la publicité',
+      description: adsRemoved ? 'Achat effectué' : 'Paiement unique pour retirer les pubs',
+      onPress: handleRemoveAds,
     },
     {
       icon: FileText,

--- a/contexts/AdsContext.tsx
+++ b/contexts/AdsContext.tsx
@@ -1,0 +1,48 @@
+import React, { createContext, useContext, useEffect, useState, ReactNode } from 'react';
+import AsyncStorage from '@react-native-async-storage/async-storage';
+
+interface AdsContextValue {
+  adsRemoved: boolean;
+  removeAds: () => Promise<void>;
+  restoreAds: () => Promise<void>;
+}
+
+const AdsContext = createContext<AdsContextValue | undefined>(undefined);
+
+const STORAGE_KEY = 'adsRemoved';
+
+export function AdsProvider({ children }: { children: ReactNode }) {
+  const [adsRemoved, setAdsRemoved] = useState(false);
+
+  useEffect(() => {
+    AsyncStorage.getItem(STORAGE_KEY).then(value => {
+      if (value === 'true') {
+        setAdsRemoved(true);
+      }
+    });
+  }, []);
+
+  const removeAds = async () => {
+    await AsyncStorage.setItem(STORAGE_KEY, 'true');
+    setAdsRemoved(true);
+  };
+
+  const restoreAds = async () => {
+    await AsyncStorage.removeItem(STORAGE_KEY);
+    setAdsRemoved(false);
+  };
+
+  return (
+    <AdsContext.Provider value={{ adsRemoved, removeAds, restoreAds }}>
+      {children}
+    </AdsContext.Provider>
+  );
+}
+
+export function useAds() {
+  const context = useContext(AdsContext);
+  if (!context) {
+    throw new Error('useAds must be used within an AdsProvider');
+  }
+  return context;
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
         "@react-navigation/bottom-tabs": "^7.2.0",
         "@react-navigation/native": "^7.0.14",
         "expo": "^53.0.0",
+        "expo-ads-admob": "~13.1.0",
         "expo-blur": "~14.1.3",
         "expo-camera": "~16.1.5",
         "expo-constants": "~17.1.3",
@@ -2490,6 +2491,12 @@
         "node": ">=18"
       }
     },
+    "node_modules/@react-native/normalize-color": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@react-native/normalize-color/-/normalize-color-2.1.0.tgz",
+      "integrity": "sha512-Z1jQI2NpdFJCVgpY+8Dq/Bt3d+YUi1928Q+/CZm/oh66fzM0RUl54vvuXlPJKybH4pdCZey1eDTPaLHkMPNgWA==",
+      "license": "MIT"
+    },
     "node_modules/@react-native/normalize-colors": {
       "version": "0.79.1",
       "resolved": "https://registry.npmjs.org/@react-native/normalize-colors/-/normalize-colors-0.79.1.tgz",
@@ -4138,6 +4145,164 @@
         "react-native-webview": {
           "optional": true
         }
+      }
+    },
+    "node_modules/expo-ads-admob": {
+      "version": "13.1.0",
+      "resolved": "https://registry.npmjs.org/expo-ads-admob/-/expo-ads-admob-13.1.0.tgz",
+      "integrity": "sha512-5ea9mG2o23c2DNS+RMVG5ddKEK3AJVvfmwPk8oNUHr3FfrJu98W9rh+cqXzFNRGO4XB0wYa2t8QN/77TivTJ0w==",
+      "license": "MIT",
+      "dependencies": {
+        "@expo/config-plugins": "~5.0.0"
+      },
+      "peerDependencies": {
+        "expo": "*"
+      }
+    },
+    "node_modules/expo-ads-admob/node_modules/@babel/code-frame": {
+      "version": "7.10.4",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.10.4.tgz",
+      "integrity": "sha512-vG6SvB6oYEhvgisZNFRmRCUkLz11c7rp+tbNTynGqc6mS1d5ATd/sGyV6W0KZZnXRKMTzZDRgQT3Ou9jhpAfUg==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/highlight": "^7.10.4"
+      }
+    },
+    "node_modules/expo-ads-admob/node_modules/@expo/config-plugins": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/@expo/config-plugins/-/config-plugins-5.0.4.tgz",
+      "integrity": "sha512-vzUcVpqOMs3h+hyRdhGwk+eGIOhXa5xYdd92yO17RMNHav3v/+ekMbs7XA2c3lepMO8Yd4/5hqmRw9ZTL6jGzg==",
+      "license": "MIT",
+      "dependencies": {
+        "@expo/config-types": "^47.0.0",
+        "@expo/json-file": "8.2.36",
+        "@expo/plist": "0.0.18",
+        "@expo/sdk-runtime-versions": "^1.0.0",
+        "@react-native/normalize-color": "^2.0.0",
+        "chalk": "^4.1.2",
+        "debug": "^4.3.1",
+        "find-up": "~5.0.0",
+        "getenv": "^1.0.0",
+        "glob": "7.1.6",
+        "resolve-from": "^5.0.0",
+        "semver": "^7.3.5",
+        "slash": "^3.0.0",
+        "xcode": "^3.0.1",
+        "xml2js": "0.4.23"
+      }
+    },
+    "node_modules/expo-ads-admob/node_modules/@expo/config-types": {
+      "version": "47.0.0",
+      "resolved": "https://registry.npmjs.org/@expo/config-types/-/config-types-47.0.0.tgz",
+      "integrity": "sha512-r0pWfuhkv7KIcXMUiNACJmJKKwlTBGMw9VZHNdppS8/0Nve8HZMTkNRFQzTHW1uH3pBj8jEXpyw/2vSWDHex9g==",
+      "license": "MIT"
+    },
+    "node_modules/expo-ads-admob/node_modules/@expo/json-file": {
+      "version": "8.2.36",
+      "resolved": "https://registry.npmjs.org/@expo/json-file/-/json-file-8.2.36.tgz",
+      "integrity": "sha512-tOZfTiIFA5KmMpdW9KF7bc6CFiGjb0xnbieJhTGlHrLL+ps2G0OkqmuZ3pFEXBOMnJYUVpnSy++52LFxvpa5ZQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "~7.10.4",
+        "json5": "^1.0.1",
+        "write-file-atomic": "^2.3.0"
+      }
+    },
+    "node_modules/expo-ads-admob/node_modules/@expo/plist": {
+      "version": "0.0.18",
+      "resolved": "https://registry.npmjs.org/@expo/plist/-/plist-0.0.18.tgz",
+      "integrity": "sha512-+48gRqUiz65R21CZ/IXa7RNBXgAI/uPSdvJqoN9x1hfL44DNbUoWHgHiEXTx7XelcATpDwNTz6sHLfy0iNqf+w==",
+      "license": "MIT",
+      "dependencies": {
+        "@xmldom/xmldom": "~0.7.0",
+        "base64-js": "^1.2.3",
+        "xmlbuilder": "^14.0.0"
+      }
+    },
+    "node_modules/expo-ads-admob/node_modules/@xmldom/xmldom": {
+      "version": "0.7.13",
+      "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.7.13.tgz",
+      "integrity": "sha512-lm2GW5PkosIzccsaZIz7tp8cPADSIlIHWDFTR1N0SzfinhhYgeIQjFMz4rYzanCScr3DqQLeomUDArp6MWKm+g==",
+      "deprecated": "this version is no longer supported, please update to at least 0.8.*",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
+    "node_modules/expo-ads-admob/node_modules/glob": {
+      "version": "7.1.6",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.6.tgz",
+      "integrity": "sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==",
+      "deprecated": "Glob versions prior to v9 are no longer supported",
+      "license": "ISC",
+      "dependencies": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.0.4",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/expo-ads-admob/node_modules/json5": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-1.0.2.tgz",
+      "integrity": "sha512-g1MWMLBiz8FKi1e4w0UyVL3w+iJceWAFBAaBnnGKOpNa5f8TLktkbre1+s6oICydWAm+HRUGTmI+//xv2hvXYA==",
+      "license": "MIT",
+      "dependencies": {
+        "minimist": "^1.2.0"
+      },
+      "bin": {
+        "json5": "lib/cli.js"
+      }
+    },
+    "node_modules/expo-ads-admob/node_modules/semver": {
+      "version": "7.7.2",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.2.tgz",
+      "integrity": "sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA==",
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/expo-ads-admob/node_modules/xml2js": {
+      "version": "0.4.23",
+      "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.4.23.tgz",
+      "integrity": "sha512-ySPiMjM0+pLDftHgXY4By0uswI3SPKLDw/i3UXbnO8M/p28zqexCUoPmQFrYD+/1BzhGJSs2i1ERWKJAtiLrug==",
+      "license": "MIT",
+      "dependencies": {
+        "sax": ">=0.6.0",
+        "xmlbuilder": "~11.0.0"
+      },
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "node_modules/expo-ads-admob/node_modules/xml2js/node_modules/xmlbuilder": {
+      "version": "11.0.1",
+      "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-11.0.1.tgz",
+      "integrity": "sha512-fDlsI/kFEx7gLvbecc0/ohLG50fugQp8ryHzMTuW9vSa1GJ0XYWKnhsUx7oie3G98+r56aTQIUB4kht42R3JvA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
+    "node_modules/expo-ads-admob/node_modules/xmlbuilder": {
+      "version": "14.0.0",
+      "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-14.0.0.tgz",
+      "integrity": "sha512-ts+B2rSe4fIckR6iquDjsKbQFK2NlUk6iG5nf14mDEyldgoc2nEKZ3jZWMPTxGQwVgToSjt6VGIho1H8/fNFTg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.0"
       }
     },
     "node_modules/expo-asset": {
@@ -8480,6 +8645,23 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ=="
+    },
+    "node_modules/write-file-atomic": {
+      "version": "2.4.3",
+      "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-2.4.3.tgz",
+      "integrity": "sha512-GaETH5wwsX+GcnzhPgKcKjJ6M2Cq3/iZp1WyY/X1CSqrW+jVNM9Y7D8EC2sM4ZG/V8wZlSniJnCKWPmBYAucRQ==",
+      "license": "ISC",
+      "dependencies": {
+        "graceful-fs": "^4.1.11",
+        "imurmurhash": "^0.1.4",
+        "signal-exit": "^3.0.2"
+      }
+    },
+    "node_modules/write-file-atomic/node_modules/signal-exit": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
+      "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
+      "license": "ISC"
     },
     "node_modules/ws": {
       "version": "8.18.1",

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "expo-print": "~14.1.4",
     "expo-file-system": "~18.1.10",
     "expo-sharing": "~13.1.5",
+    "expo-ads-admob": "~13.1.0",
     "@expo-google-fonts/roboto": "^0.2.3",
     "lucide-react-native": "^0.475.0",
     "react": "19.0.0",


### PR DESCRIPTION
## Summary
- implement `AdsContext` to store ad-removal state
- add `AdBanner` component using AdMob
- wrap application with `AdsProvider`
- allow removing ads from settings
- show banners on main screens
- add `expo-ads-admob` dependency

## Testing
- `npm run lint` *(fails: fetch failed due to network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_684fd6d8aea88320a9ac18c1552ba9c6