### PR TITLE
Remove expo-router plugin from babel config

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -4,7 +4,6 @@ module.exports = function (api) {
     presets: ['babel-preset-expo'],
     plugins: [
       ['module-resolver', { alias: { '@': './' } }],
-      'expo-router/babel',
     ],
   };
 };


### PR DESCRIPTION
## Summary
- remove deprecated `expo-router/babel` plugin from `babel.config.js`

## Testing
- `npm run lint` *(fails: fetch failed due to network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_684fe9ea9c5c8320864e83ee142cedd7