### PR TITLE
Fix button variant in history empty state

### DIFF
--- a/components/EmptyState.tsx
+++ b/components/EmptyState.tsx
@@ -66,7 +66,7 @@ export default function EmptyState({
           <ActionButton
             title={actionTitle}
             onPress={onAction}
-            variant="outline"
+            variant="primary"
             size="medium"
           />
         </View>


### PR DESCRIPTION
## Summary
- use `primary` ActionButton variant on EmptyState so history screen matches other "Créer un courrier" buttons

## Testing
- `npm run lint` *(fails: fetch failed)*

------
https://chatgpt.com/codex/tasks/task_e_684fec80f080832084ace7de1f808909